### PR TITLE
clean up warnings not from component/hook libraries

### DIFF
--- a/src/components/ToolbarCustom.jsx
+++ b/src/components/ToolbarCustom.jsx
@@ -170,7 +170,7 @@ export default function ToolbarCustom(toolbarCustomProps) {
   );
 }
 
-ToolbarLineHeight.propTypes = {
+ToolbarCustom.propTypes = {
   /** Selected Font Name */
   selectedFontName: PropTypes.string,
   /** Set Selected Font Name */
@@ -196,43 +196,43 @@ ToolbarLineHeight.propTypes = {
   /** Handle Prevent Click */
   handlePreventClick: PropTypes.func.isRequired,
   /** Hook on medial heh-goal */
-  hehk: PropTypes.string,
+  hehk: PropTypes.number,
   /** Set hook on medial heh-goal */
   setHehk: PropTypes.func.isRequired,
   /** Initial heh doachashmee */
-  hedo: PropTypes.string,
+  hedo: PropTypes.number,
   /** Set initial heh doachashmee */
   setHedo: PropTypes.func.isRequired,
   /** Lam with V */
-  lamv: PropTypes.string,
+  lamv: PropTypes.number,
   /** Set lam with V */
   setLamv: PropTypes.func.isRequired,
   /** Full stop */
-  cv85: PropTypes.string,
+  cv85: PropTypes.number,
   /** Set full stop */
   setCv85: PropTypes.func.isRequired,
   /** Sukun/jazm */
-  cv78: PropTypes.string,
+  cv78: PropTypes.number,
   /** Set sukun/jazm */
   setCv78: PropTypes.func.isRequired,
   /** Hamza */
-  hamz: PropTypes.string,
+  hamz: PropTypes.number,
   /** Set hamza */
   setHamz: PropTypes.func.isRequired,
   /** Punctuation */
-  punc: PropTypes.string,
+  punc: PropTypes.number,
   /** Set punctuation */
   setPunc: PropTypes.func.isRequired,
   /** Word spacing */
-  wdsp: PropTypes.string,
+  wdsp: PropTypes.number,
   /** Set word spacing */
   setWdsp: PropTypes.func.isRequired,
   /** Short forms */
-  shrt: PropTypes.string,
+  shrt: PropTypes.number,
   /** Set short forms */
   setShrt: PropTypes.func.isRequired,
   /** Collision avoidance */
-  agca: PropTypes.string,
+  agca: PropTypes.number,
   /** Set collision avoidance */
   setAgca: PropTypes.func.isRequired,
 };

--- a/src/components/ToolbarFontSize.jsx
+++ b/src/components/ToolbarFontSize.jsx
@@ -65,7 +65,6 @@ export default function ToolbarFontSize(ToolbarFontSizeProps) {
                   id="fontSize"
                   name="fontSize"
                   inputRef={refFontSize}
-                  defaultValue={fontSize}
                   value={fontSizeValue}
                   onChange={handleEnsureNumber}
                 />

--- a/src/components/ToolbarFontSize.jsx
+++ b/src/components/ToolbarFontSize.jsx
@@ -58,7 +58,7 @@ export default function ToolbarFontSize(ToolbarFontSizeProps) {
                     '& .MuiInputAdornment-root': {fontSize: '.9em',fontWeight: 'bolder'}
                   },
                   endAdornment:
-                    <InputAdornment position="end" classes="sizeSmall" sx={{position: 'absolute', right: 23 , bottom: 7 }}>%</InputAdornment>,
+                    <InputAdornment position="end" sx={{position: 'absolute', right: 23 , bottom: 7 }}>%</InputAdornment>,
                  }}
                   placeholder="Size"
                   type="text"

--- a/src/components/ToolbarLineHeight.jsx
+++ b/src/components/ToolbarLineHeight.jsx
@@ -28,7 +28,9 @@ export default function ToolbarLineHeight(ToolbarLineHeightProps) {
   }, [lineHeightValue]);
 
   useEffect(() => {
-    setSelectedLineHeight(lineHeight / 100);
+    const lineHeightNum = lineHeight / 100;
+    const lineHeightString = lineHeightNum.toString();
+    setSelectedLineHeight(lineHeightString);
   }, [lineHeight, selectedLineHeight, setSelectedLineHeight]);
 
   const refLineHeight = React.useRef();

--- a/src/components/ToolbarLineHeight.jsx
+++ b/src/components/ToolbarLineHeight.jsx
@@ -57,7 +57,7 @@ export default function ToolbarLineHeight(ToolbarLineHeightProps) {
                     '& .MuiInputAdornment-root': {fontSize: '.9em'}
                   },
                   endAdornment:
-                    <InputAdornment position="end" classes="sizeSmall" sx={{position: 'absolute', right: 23, bottom: 7 }}>%</InputAdornment>,
+                    <InputAdornment position="end" sx={{position: 'absolute', right: 23, bottom: 7 }}>%</InputAdornment>,
                  }}
                   placeholder="Height"
                   type="text"

--- a/src/components/ToolbarLineHeight.jsx
+++ b/src/components/ToolbarLineHeight.jsx
@@ -66,7 +66,6 @@ export default function ToolbarLineHeight(ToolbarLineHeightProps) {
                   id="lineHeight"
                   name="lineHeight"
                   inputRef={refLineHeight}
-                  defaultValue={lineHeight}
                   value={lineHeightValue}
                   onChange={handleEnsureNumber}
                 />


### PR DESCRIPTION
- remove unrecognized class statement
- address propType string/value consistency and component name
- avoid setting propType of both defaultValue and value on the same field