### PR TITLE
Address android font feature settings styles and remove iPad Graphite font option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translatable",
   "license": "MIT",
-  "version": "0.1.01",
+  "version": "0.1.02",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ToolbarFontFeatures.jsx
+++ b/src/components/ToolbarFontFeatures.jsx
@@ -303,7 +303,7 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
                 </RadioGroup>
               </Grid>
             </Grid>
-            <FormLabel id="lam-with-v-label"><div style={labelDivStyle}><mark style={labelMarkStyle}>Punctuation</mark></div></FormLabel>
+            <FormLabel id="punctuation-label"><div style={labelDivStyle}><mark style={labelMarkStyle}>Punctuation</mark></div></FormLabel>
               <RadioGroup
                 aria-labelledby="punctuation-label"
                 defaultValue="0"

--- a/src/components/ToolbarFontFeatures.jsx
+++ b/src/components/ToolbarFontFeatures.jsx
@@ -189,8 +189,8 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
               onChange={handleHehkChange}
               sx={radioColor}
             >
-              <Tooltip title="Yes" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"hehk" 1' }} control={<Radio />} label={<Typography sx={label}>ب<font color={fontColor}>ہ</font>ب ب<font color={fontColor}>ۂ</font>ب</Typography>} /></Tooltip>
-              <Tooltip title="No" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"hehk" 0' }} control={<Radio />} label={<Typography sx={label}>ب<font color={fontColor}>ہ</font>ب ب<font color={fontColor}>ۂ</font>ب</Typography>} /></Tooltip>
+              <Tooltip title="Yes" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"hehk" 1', MozFontFeatureSettings: '"hehk" 1', WebkitFontFeatureSettings: '"hehk" 1' }} control={<Radio />} label={<Typography sx={label}>ب<font color={fontColor}>ہ</font>ب ب<font color={fontColor}>ۂ</font>ب</Typography>} /></Tooltip>
+              <Tooltip title="No" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"hehk" 0', MozFontFeatureSettings: '"hehk" 0', WebkitFontFeatureSettings: '"hehk" 0' }} control={<Radio />} label={<Typography sx={label}>ب<font color={fontColor}>ہ</font>ب ب<font color={fontColor}>ۂ</font>ب</Typography>} /></Tooltip>
             </RadioGroup>
             <FormLabel id="initial-heh-doachashmee-label"><div style={labelDivStyle}><br /><mark style={labelMarkStyle}>Initial heh doachashmee</mark></div></FormLabel>
             <RadioGroup
@@ -201,8 +201,8 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
               onChange={handleHedoChange}
               sx={radioColor}
             >
-              <Tooltip title="Heart shaped" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"hedo" 0' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ھ</font>ا</Typography>} /></Tooltip>
-              <Tooltip title="Round" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"hedo" 1' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ھ</font>ا</Typography>} /></Tooltip>
+              <Tooltip title="Heart shaped" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"hedo" 0', MozFontFeatureSettings: '"hedo" 0', WebkitFontFeatureSettings: '"hedo" 0' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ھ</font>ا</Typography>} /></Tooltip>
+              <Tooltip title="Round" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"hedo" 1', MozFontFeatureSettings: '"hedo" 1', WebkitFontFeatureSettings: '"hedo" 1' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ھ</font>ا</Typography>} /></Tooltip>
             </RadioGroup>
             <FormLabel id="lam-with-v-label"><div style={labelDivStyle}><br /><mark style={labelMarkStyle}>Lam with V</mark></div></FormLabel>
             <RadioGroup
@@ -213,8 +213,8 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
               onChange={handleLamvChange}
               sx={radioColor}
             >
-              <Tooltip title="V over stem" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"lamv" 0' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ڵ</font> ڵبڵب<font color={fontColor}>ڵ</font></Typography>} /></Tooltip>
-              <Tooltip title="V over bowl" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"lamv" 1' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ڵ</font> ڵبڵب<font color={fontColor}>ڵ</font></Typography>} /></Tooltip>
+              <Tooltip title="V over stem" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"lamv" 0', MozFontFeatureSettings: '"lamv" 0', WebkitFontFeatureSettings: '"lamv" 0' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ڵ</font> ڵبڵب<font color={fontColor}>ڵ</font></Typography>} /></Tooltip>
+              <Tooltip title="V over bowl" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"lamv" 1', MozFontFeatureSettings: '"lamv" 1', WebkitFontFeatureSettings: '"lamv" 1' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>ڵ</font> ڵبڵب<font color={fontColor}>ڵ</font></Typography>} /></Tooltip>
             </RadioGroup>
             <FormLabel id="full-stop-label"><div style={labelDivStyle}><br /><mark style={labelMarkStyle}>Full Stop</mark></div></FormLabel>
             <RadioGroup
@@ -225,8 +225,8 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
               onChange={handleCv85Change}
               sx={radioColor}
             >
-               <Tooltip title="Dash" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"cv85" 0' }} control={<Radio />} label={<Typography sx={label}>ججج<font color={fontColor}>۔</font></Typography>} /></Tooltip>
-               <Tooltip title="Dot" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"cv85" 1' }} control={<Radio />} label={<Typography sx={label}>ججج<font color={fontColor}>۔</font></Typography>} /></Tooltip>
+               <Tooltip title="Dash" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"cv85" 0', MozFontFeatureSettings: '"cv85" 0', WebkitFontFeatureSettings: '"cv85" 0' }} control={<Radio />} label={<Typography sx={label}>ججج<font color={fontColor}>۔</font></Typography>} /></Tooltip>
+               <Tooltip title="Dot" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"cv85" 1', MozFontFeatureSettings: '"cv85" 1', WebkitFontFeatureSettings: '"cv85" 1' }} control={<Radio />} label={<Typography sx={label}>ججج<font color={fontColor}>۔</font></Typography>} /></Tooltip>
             </RadioGroup>
             <FormLabel id="sukun-jazm-label"><div style={labelDivStyle}><br /><mark style={labelMarkStyle}>Sukun/jazm</mark></div></FormLabel>
             <RadioGroup
@@ -237,8 +237,8 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
               onChange={handleCv78Change}
               sx={radioColor}
             >
-              <Tooltip title="Open down" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"cv78" 1' }} control={<Radio />} label={<Typography sx={label}>بْ ◌ْ</Typography>} /></Tooltip>
-              <Tooltip title="Open left" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"cv78" 2' }} control={<Radio />} label={<Typography sx={label}>بْ ◌ْ</Typography>} /></Tooltip>
+              <Tooltip title="Open down" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"cv78" 1', MozFontFeatureSettings: '"cv78" 1', WebkitFontFeatureSettings: '"cv78" 1' }} control={<Radio />} label={<Typography sx={label}>بْ ◌ْ</Typography>} /></Tooltip>
+              <Tooltip title="Open left" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"cv78" 2', MozFontFeatureSettings: '"cv78" 2', WebkitFontFeatureSettings: '"cv78" 2' }} control={<Radio />} label={<Typography sx={label}>بْ ◌ْ</Typography>} /></Tooltip>
             </RadioGroup>
           </Grid>
           <Grid item xs={9}>
@@ -253,8 +253,8 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
                   onChange={handleHamzChange}
                   sx={radioColor}
                 >
-                  <Tooltip title="Urdu style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"hamz" 0' }} control={<Radio />} label={<Typography sx={label}>ء أ ؤ بؤ إ ۂ بۂ ۓ بۓ ٵ ݬ بݬ ځ بځ بځب بٔ بٕ</Typography>} /></Tooltip>
-                  <Tooltip title="Arabic style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"hamz" 1' }} control={<Radio />} label={<Typography sx={label}>ء أ ؤ بؤ إ ۂ بۂ ۓ بۓ ٵ ݬ بݬ ځ بځ بځب بٔ بٕ</Typography>} /></Tooltip>
+                  <Tooltip title="Urdu style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"hamz" 0', MozFontFeatureSettings: '"hamz" 0', WebkitFontFeatureSettings: '"hamz" 0' }} control={<Radio />} label={<Typography sx={label}>ء أ ؤ بؤ إ ۂ بۂ ۓ بۓ ٵ ݬ بݬ ځ بځ بځب بٔ بٕ</Typography>} /></Tooltip>
+                  <Tooltip title="Arabic style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"hamz" 1', MozFontFeatureSettings: '"hamz" 1', WebkitFontFeatureSettings: '"hamz" 1' }} control={<Radio />} label={<Typography sx={label}>ء أ ؤ بؤ إ ۂ بۂ ۓ بۓ ٵ ݬ بݬ ځ بځ بځب بٔ بٕ</Typography>} /></Tooltip>
                 </RadioGroup>
                 <FormLabel id="word-spacing-label"><div style={labelDivStyle}><br /><mark style={labelMarkStyle}>Word spacing</mark></div></FormLabel>
                 <RadioGroup
@@ -265,11 +265,11 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
                   onChange={handleWdspChange}
                   sx={radioColor}
                 >
-                  <Tooltip title="Extra tight" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"wdsp" 0' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
-                  <Tooltip title="Tight" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"wdsp" 1' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
-                  <Tooltip title="Medium" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"wdsp" 2' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
-                  <Tooltip title="Wide" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="3" style={{ fontFeatureSettings: '"wdsp" 3' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
-                  <Tooltip title="Extra wide" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="4" style={{ fontFeatureSettings: '"wdsp" 4' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
+                  <Tooltip title="Extra tight" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"wdsp" 0', MozFontFeatureSettings: '"wdsp" 0', WebkitFontFeatureSettings: '"wdsp" 0' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
+                  <Tooltip title="Tight" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"wdsp" 1', MozFontFeatureSettings: '"wdsp" 1', WebkitFontFeatureSettings: '"wdsp" 1' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
+                  <Tooltip title="Medium" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"wdsp" 2', MozFontFeatureSettings: '"wdsp" 2', WebkitFontFeatureSettings: '"wdsp" 2' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
+                  <Tooltip title="Wide" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="3" style={{ fontFeatureSettings: '"wdsp" 3', MozFontFeatureSettings: '"wdsp" 3', WebkitFontFeatureSettings: '"wdsp" 3' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
+                  <Tooltip title="Extra wide" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="4" style={{ fontFeatureSettings: '"wdsp" 4', MozFontFeatureSettings: '"wdsp" 4', WebkitFontFeatureSettings: '"wdsp" 4' }} control={<Radio />} label={<Typography sx={label}>کیوں جو انسانی حقوق کنوں</Typography>} /></Tooltip>
                 </RadioGroup>
               </Grid>
               <Grid item xs={5}>
@@ -282,10 +282,10 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
                   onChange={handleAgcaChange}
                   sx={radioColor}
                 >
-                  <Tooltip title="On" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="3" style={{ fontFeatureSettings: '"agca" 3' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج</Typography>} /></Tooltip>
-                  {/** <Tooltip title="Not implemented" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"agca" 2' }} control={<Radio />} label={<Typography sx={label}>پیٹی اؔبِیجیل تحرِیج</Typography>} /></Tooltip> */}
-                  <Tooltip title="Kern-only" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"agca" 1' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج</Typography>} /></Tooltip>
-                  <Tooltip title="Off" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"agca" 0' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج</Typography>} /></Tooltip>
+                  <Tooltip title="On" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="3" style={{ fontFeatureSettings: '"agca" 3', MozFontFeatureSettings: '"agca" 3', WebkitFontFeatureSettings: '"agca" 3' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج</Typography>} /></Tooltip>
+                  {/** <Tooltip title="Not implemented" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"agca" 2', MozFontFeatureSettings: '"agca" 2', WebkitFontFeatureSettings: '"agca" 2' }} control={<Radio />} label={<Typography sx={label}>پیٹی اؔبِیجیل تحرِیج</Typography>} /></Tooltip> */}
+                  <Tooltip title="Kern-only" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"agca" 1', MozFontFeatureSettings: '"agca" 1', WebkitFontFeatureSettings: '"agca" 1' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج</Typography>} /></Tooltip>
+                  <Tooltip title="Off" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"agca" 0', MozFontFeatureSettings: '"agca" 0', WebkitFontFeatureSettings: '"agca" 0' }} control={<Radio />} label={<Typography sx={label}><font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج</Typography>} /></Tooltip>
                 </RadioGroup>
                 <FormLabel id="short-forms-label"><div style={labelDivStyle}><br /><mark style={labelMarkStyle}>Short forms</mark><br />&nbsp;</div></FormLabel>
                 <RadioGroup
@@ -296,10 +296,10 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
                   onChange={handleShrtChange}
                   sx={radioColor}
                 >
-                  <Tooltip title="All" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="3" style={{ fontFeatureSettings: '"shrt" 3' }} control={<Radio />} label={<Typography sx={label}>دی<font color={fontColor}>ک</font>ھت<font color={fontColor}>ی</font> <font color={fontColor}>ک</font>نسلٹنٹ<font color={fontColor}>س</font> ن<font color={fontColor}>گ</font>ھنے ت<font color={fontColor}>ک</font>می<font color={fontColor}>ل</font></Typography>} /></Tooltip>
-                  <Tooltip title="Finals" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"shrt" 2' }} control={<Radio />} label={<Typography sx={label}>دیکھت<font color={fontColor}>ی</font> کنسلٹنٹ<font color={fontColor}>س</font> نگھنے تکمی<font color={fontColor}>ل</font></Typography>} /></Tooltip>
-                  <Tooltip title="Kafs and gafs" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"shrt" 1' }} control={<Radio />} label={<Typography sx={label}>دی<font color={fontColor}>ک</font>ھتی <font color={fontColor}>ک</font>نسلٹنٹس ن<font color={fontColor}>گ</font>ھنے ت<font color={fontColor}>ک</font>میل</Typography>} /></Tooltip>
-                  <Tooltip title="None" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"shrt" 0' }} control={<Radio />} label={<Typography sx={label}>دیکھتی کنسلٹنٹس نگھنے تکمیل</Typography>} /></Tooltip>
+                  <Tooltip title="All" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="3" style={{ fontFeatureSettings: '"shrt" 3', MozFontFeatureSettings: '"shrt" 3', WebkitFontFeatureSettings: '"shrt" 3' }} control={<Radio />} label={<Typography sx={label}>دی<font color={fontColor}>ک</font>ھت<font color={fontColor}>ی</font> <font color={fontColor}>ک</font>نسلٹنٹ<font color={fontColor}>س</font> ن<font color={fontColor}>گ</font>ھنے ت<font color={fontColor}>ک</font>می<font color={fontColor}>ل</font></Typography>} /></Tooltip>
+                  <Tooltip title="Finals" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"shrt" 2', MozFontFeatureSettings: '"shrt" 2', WebkitFontFeatureSettings: '"shrt" 2' }} control={<Radio />} label={<Typography sx={label}>دیکھت<font color={fontColor}>ی</font> کنسلٹنٹ<font color={fontColor}>س</font> نگھنے تکمی<font color={fontColor}>ل</font></Typography>} /></Tooltip>
+                  <Tooltip title="Kafs and gafs" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"shrt" 1', MozFontFeatureSettings: '"shrt" 1', WebkitFontFeatureSettings: '"shrt" 1' }} control={<Radio />} label={<Typography sx={label}>دی<font color={fontColor}>ک</font>ھتی <font color={fontColor}>ک</font>نسلٹنٹس ن<font color={fontColor}>گ</font>ھنے ت<font color={fontColor}>ک</font>میل</Typography>} /></Tooltip>
+                  <Tooltip title="None" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"shrt" 0', MozFontFeatureSettings: '"shrt" 0', WebkitFontFeatureSettings: '"shrt" 0' }} control={<Radio />} label={<Typography sx={label}>دیکھتی کنسلٹنٹس نگھنے تکمیل</Typography>} /></Tooltip>
                 </RadioGroup>
               </Grid>
             </Grid>
@@ -312,9 +312,9 @@ export default function ToolbarFontFeatures(ToolbarFontFeaturesProps) {
                 onChange={handlePuncChange}
                 sx={radioColor}
               >
-                <Tooltip title="Arabic (RTL) and Latin (LTR) styles" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"punc" 0' }} control={<Radio />} label={<Typography sx={label}>! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ </Typography>} /></Tooltip>
-                <Tooltip title="Arabic-style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"punc" 1' }} control={<Radio />} label={<Typography sx={label}>! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ </Typography>} /></Tooltip>
-                <Tooltip title="Latin-style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"punc" 2' }} control={<Radio />} label={<Typography sx={label}>! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ </Typography>} /></Tooltip>
+                <Tooltip title="Arabic (RTL) and Latin (LTR) styles" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="0" style={{ fontFeatureSettings: '"punc" 0', MozFontFeatureSettings: '"punc" 0', WebkitFontFeatureSettings: '"punc" 0' }} control={<Radio />} label={<Typography sx={label}>! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ </Typography>} /></Tooltip>
+                <Tooltip title="Arabic-style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="1" style={{ fontFeatureSettings: '"punc" 1', MozFontFeatureSettings: '"punc" 1', WebkitFontFeatureSettings: '"punc" 1' }} control={<Radio />} label={<Typography sx={label}>! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ </Typography>} /></Tooltip>
+                <Tooltip title="Latin-style" placement="right" PopperProps={tooltipPosition} arrow={true}><FormControlLabel value="2" style={{ fontFeatureSettings: '"punc" 2', MozFontFeatureSettings: '"punc" 2', WebkitFontFeatureSettings: '"punc" 2' }} control={<Radio />} label={<Typography sx={label}>! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ </Typography>} /></Tooltip>
               </RadioGroup>
           </Grid>
         </Grid>

--- a/src/components/ToolbarGraphite.jsx
+++ b/src/components/ToolbarGraphite.jsx
@@ -1,16 +1,17 @@
-import { useAssumeGraphite } from "font-detect-rhl";
+// import { useAssumeGraphite } from "font-detect-rhl";
 import PropTypes from 'prop-types';
 
 // Firefox on iPadOS is notoriously difficult to autodetect. We can show this button if Firefox is not auto-detected.
 export default function ToolbarGraphite(ToolbarGraphiteProps) {
   const { assumeGraphite, handleGraphiteClick } = ToolbarGraphiteProps;
 
+  /**
   const isFirefoxDetected = useAssumeGraphite({});
 
-  /**
-   iPad userAgent for Firefox = Safari, so usAssumeGraphite returns a false negative.
-   So we can let users tell us if they are using Firefox on iPad.
-  */
+   // iPad userAgent for Firefox = Safari, so usAssumeGraphite returns a false negative. So we can let users tell us if they are using Firefox on iPad.
+   //   However, Graphite is not included in Firefox on iPad. So we are deactivating this feature for iPad.
+   // We will holding on to it here for a bit, in event other scenarios are identified where a manual override is useful.
+   //   Developing a method of Graphite feature detection, if possible, would ultimately be the best solution! 
 
     const uA = navigator.userAgent.toLowerCase();
 
@@ -23,7 +24,10 @@ export default function ToolbarGraphite(ToolbarGraphiteProps) {
     const isIpad = ((uA.indexOf('ipad') > -1) || ((uA.indexOf('mac') > -1) && navigator.maxTouchPoints &&  (navigator.maxTouchPoints > 2)));
 
     const askUser = (!isFirefoxDetected && isIpad ? true : false);
-  
+  */
+
+  const askUser = false;
+
   const graphiteSwitch = assumeGraphite ? "Yes" : "No"
 
   const graphiteButton = (<button style={{height: "4.645em", margin: "0.1em auto"}} id="graphite" value={assumeGraphite} onClick={handleGraphiteClick}>Firefox?<br />{graphiteSwitch}</button>);

--- a/src/fontFeatures/awamiNastaliq.json
+++ b/src/fontFeatures/awamiNastaliq.json
@@ -1,0 +1,219 @@
+[
+    {
+      "name": "Awami Nastaliq",
+      "id": "awami-nastaliq",
+      "Character variants": [
+        {
+        "Hook on medial heh-goal": [
+          {
+            "name": "hehk",
+            "id": "hook-on-medial-heh-goal-label",
+            "default": "1",
+            "label": "ب<font color={fontColor}>ہ</font>ب ب<font color={fontColor}>ۂ</font>ب",
+            "Options": [
+              {
+                "tip": "Yes",
+                "value": "1"
+              },
+              {
+                "tip": "No",
+                "value": "0"
+              }
+            ]
+          }
+        ],
+        "Initial heh doachashmee": [
+            {
+            "name": "hedo",
+            "id": "initial-heh-doachashmee-label",
+            "default": "0",
+            "label": "<font color={fontColor}>ھ</font>ا",
+            "Options": [
+              {
+                "tip": "Heart shaped",
+                "value": "0"
+              },
+              {
+                "tip": "Round",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Lam with V": [
+            {
+            "name": "lamv",
+            "id": "lam-with-v-label",
+            "default": "0",
+            "label": "<font color={fontColor}>ڵ</font> ڵبڵب<font color={fontColor}>ڵ</font>",
+            "Options": [
+              {
+                "tip": "V over stem",
+                "value": "0"
+              },
+              {
+                "tip": "V over bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Full Stop": [
+            {
+            "name": "cv85",
+            "id": "full-stop-label",
+            "default": "0",
+            "label": "ججج<font color={fontColor}>۔</font>",
+            "Options": [
+              {
+                "tip": "Dash",
+                "value": "0"
+              },
+              {
+                "tip": "Dot",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Sukun/jazm": [
+            {
+            "name": "cv78",
+            "id": "sukun-jazm-label",
+            "default": "1",
+            "label": "بْ ◌ْ",
+            "Options": [
+              {
+                "tip": "Open down",
+                "value": "1"
+              },
+              {
+                "tip": "Open left",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Hamza": [
+            {
+            "name": "hamz",
+            "id": "hamza-label",
+            "default": "0",
+            "label": "ء أ ؤ بؤ إ ۂ بۂ ۓ بۓ ٵ ݬ بݬ ځ بځ بځب بٔ بٕ",
+            "Options": [
+              {
+                "tip": "Urdu style",
+                "value": "0"
+              },
+              {
+                "tip": "Arabic style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Word spacing": [
+            {
+            "name": "wdsp",
+            "id": "word-spacing-label",
+            "default": "2",
+            "label": "کیوں جو انسانی حقوق کنوں",
+            "Options": [
+              {
+                "tip": "Extra tight",
+                "value": "0"
+              },
+              {
+                "tip": "Tight",
+                "value": "1"
+              },
+              {
+                "tip": "Medium",
+                "value": "2"
+              },
+              {
+                "tip": "Wide",
+                "value": "3"
+              },
+              {
+                "tip": "Extra wide",
+                "value": "4"
+              }
+            ]
+          }
+        ],
+        "Collision avoidance": [
+            {
+            "name": "agca",
+            "id": "collision-avoidance-label",
+            "default": "3",
+            "label": "<font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج",
+            "Options": [
+              {
+                "tip": "On",
+                "value": "3"
+              },
+              {
+                "tip": "Kern-only",
+                "value": "1"
+              },
+              {
+                "tip": "Off",
+                "value": "0"
+              }
+            ]
+          }
+        ],
+        "Short forms": [
+            {
+            "name": "shrt",
+            "id": "short-forms-label",
+            "default": "3",
+            "label": "دی<font color={fontColor}>ک</font>ھت<font color={fontColor}>ی</font> <font color={fontColor}>ک</font>نسلٹنٹ<font color={fontColor}>س</font> ن<font color={fontColor}>گ</font>ھنے ت<font color={fontColor}>ک</font>می<font color={fontColor}>ل</font>",
+            "Options": [
+              {
+                "tip": "All",
+                "value": "3"
+              },
+              {
+                "tip": "Finals",
+                "value": "2"
+              },
+              {
+                "tip": "Kafs and gafs",
+                "value": "1"
+              },
+              {
+                "tip": "None",
+                "value": "0"
+              }
+            ]
+          }
+        ],
+        "Punctuation": [
+            {
+            "name": "punc",
+            "id": "punctuation-label",
+            "default": "0",
+            "label": "! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ ",
+            "Options": [
+              {
+                "tip": "Arabic (RTL) and Latin (LTR) styles",
+                "value": "0"
+              },
+              {
+                "tip": "Arabic-style",
+                "value": "1"
+              },
+              {
+                "tip": "Latin-style",
+                "value": "2"
+              }
+            ]
+          }
+        ]
+        }
+      ]
+    }
+  ]
+  

--- a/src/fontFeatures/graphiteEnabledFeatures.json
+++ b/src/fontFeatures/graphiteEnabledFeatures.json
@@ -1,0 +1,6484 @@
+[
+  {
+    "name": "Abyssinica SIL",
+    "id": "abyssinica-sil",
+    "Character variants": [
+      {
+        "Punctuation": [
+          {
+            "name": "cv01",
+            "id": "punctuation-label",
+            "default": "0",
+            "label": "! $ % * + / 0 1 2 3 4 5 6 7 8 9 = ? ¡ © « ² ³ ¹ » × ‘ ’ “ ” ‹ › ⁰ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ €",
+            "Options": [
+              {
+                "tip": "Ethiopic-style",
+                "value": "0"
+              },
+              {
+                "tip": "Latin-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ethiopic digits": [
+          {
+            "name": "cv02",
+            "id": "ethiopic-digits-label",
+            "default": "0",
+            "label": "፩ ፪፫ ፫፬፭ ፺፻፼፻፼፩፼፩፪",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Connected",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "mwa alternates": [
+          {
+            "name": "cv04",
+            "id": "mwa-alternates-label",
+            "default": "0",
+            "label": "ሟ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate-1",
+                "value": "1"
+              },
+              {
+                "tip": "Alternate-2",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "rwa alternate": [
+          {
+            "name": "cv05",
+            "id": "rwa-alternate-label",
+            "default": "0",
+            "label": "ሯ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "xoa alternate": [
+          {
+            "name": "cv17",
+            "id": "xoa-alternate-label",
+            "default": "0",
+            "label": "ኇ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "xwa alternates": [
+          {
+            "name": "cv18",
+            "id": "xwa-alternates-label",
+            "default": "0",
+            "label": "ኈ ኊ ኋ ኌ ኍ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Handwriting",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "nwa alternate": [
+          {
+            "name": "cv19",
+            "id": "nwa-alternate-label",
+            "default": "0",
+            "label": "ኗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "nya alternates": [
+          {
+            "name": "cv20",
+            "id": "nya-alternates-label",
+            "default": "0",
+            "label": "ኘ ኙ ኚ ኛ ኜ ኝ ኞ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Disconnected",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "nywa alternates": [
+          {
+            "name": "cv21",
+            "id": "nywa-alternates-label",
+            "default": "0",
+            "label": "ኟ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Disconnected",
+                "value": "1"
+              },
+              {
+                "tip": "Cohen",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "kxwaa alternate": [
+          {
+            "name": "cv26",
+            "id": "kxwaa-alternate-label",
+            "default": "0",
+            "label": "ዃ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "zha alternates": [
+          {
+            "name": "cv31",
+            "id": "zha-alternates-label",
+            "default": "0",
+            "label": "ዠ ዡ ዢ ዣ ዤ ዥ ዦ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Cohen",
+                "value": "1"
+              },
+              {
+                "tip": "Chaine",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "dda alternates": [
+          {
+            "name": "cv32",
+            "id": "dda-alternates-label",
+            "default": "0",
+            "label": "ዸ ዹ ዺ ዻ ዼ ዽ ዾ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "gwaa alternates": [
+          {
+            "name": "cv40",
+            "id": "gwaa-alternates-label",
+            "default": "0",
+            "label": "ጓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Sebat Bet",
+                "value": "1"
+              },
+              {
+                "tip": "Alone Stokes",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "gga alternates": [
+          {
+            "name": "cv41",
+            "id": "gga-alternates-label",
+            "default": "0",
+            "label": "ጘ ጙ ጚ ጛ ጜ ጝ ጞ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Disconnected",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "ggwaa alternate": [
+          {
+            "name": "cv42",
+            "id": "ggwaa-alternate-label",
+            "default": "0",
+            "label": "ጟ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Disconnected",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "phe alternate": [
+          {
+            "name": "cv45",
+            "id": "phe-alternate-label",
+            "default": "0",
+            "label": "ጵ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "tswa alternate": [
+          {
+            "name": "cv46",
+            "id": "tswa-alternate-label",
+            "default": "0",
+            "label": "ጿ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "fwa alternates": [
+          {
+            "name": "cv48",
+            "id": "fwa-alternates-label",
+            "default": "0",
+            "label": "ፏ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Cohen-1",
+                "value": "1"
+              },
+              {
+                "tip": "Cohen-2",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "rya alternate": [
+          {
+            "name": "cv49",
+            "id": "rya-alternate-label",
+            "default": "0",
+            "label": "ፘ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "mya alternate": [
+          {
+            "name": "cv50",
+            "id": "mya-alternate-label",
+            "default": "0",
+            "label": "ፙ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "mwi alternates": [
+          {
+            "name": "cv60",
+            "id": "mwi-alternates-label",
+            "default": "0",
+            "label": "ᎁ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Sebat Bet",
+                "value": "1"
+              },
+              {
+                "tip": "Leslau",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "mwe alternates": [
+          {
+            "name": "cv61",
+            "id": "mwe-alternates-label",
+            "default": "0",
+            "label": "ᎃ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Sebat Bet",
+                "value": "1"
+              },
+              {
+                "tip": "Leslau",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "bwe alternate": [
+          {
+            "name": "cv62",
+            "id": "bwe-alternate-label",
+            "default": "0",
+            "label": "ᎇ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "fwee alternate": [
+          {
+            "name": "cv63",
+            "id": "fwee-alternate-label",
+            "default": "0",
+            "label": "ᎊ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "fwe alternate": [
+          {
+            "name": "cv64",
+            "id": "fwe-alternate-label",
+            "default": "0",
+            "label": "ᎋ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "pwe alternate": [
+          {
+            "name": "cv65",
+            "id": "pwe-alternate-label",
+            "default": "0",
+            "label": "ᎏ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "ggwa alternates": [
+          {
+            "name": "cv70",
+            "id": "ggwa-alternates-label",
+            "default": "0",
+            "label": "ⶓ ⶔ ⶕ ⶖ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Disconnected",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "3rd form alternates": [
+          {
+            "name": "cv80",
+            "id": "3rd-form-alternates-label",
+            "default": "0",
+            "label": "ቊ ኲ ዂ ጒ ᎅ ᎍ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "6th form alternates": [
+          {
+            "name": "cv85",
+            "id": "6th-form-alternates-label",
+            "default": "0",
+            "label": "ቍ ኵ ዅ ጕ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Alkalami",
+    "id": "alkalami",
+    "Stylistic Sets": [
+      {
+        "Imala e": [
+          {
+            "name": "ss04",
+            "id": "imala-e-label",
+            "default": "0",
+            "label": "بٜ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Jeem/Hah": [
+          {
+            "name": "ss07",
+            "id": "jeem/hah-label",
+            "default": "0",
+            "label": "ج ججج ح ححح خ خخخ ڃ ڃڃڃ ڄ ڄڄڄ ࢢ ࢢࢢࢢ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Flat style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Alef diacritic placement": [
+          {
+            "name": "ss08",
+            "id": "alef-diacritic-placement-label",
+            "default": "0",
+            "label": "اَ اُ اِ باَ باُ باِ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Touching",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Wagaf": [
+          {
+            "name": "ss09",
+            "id": "wagaf-label",
+            "default": "0",
+            "label": "ؿ ؿؿؿ ڟ ڟڟڟ ݑ ݑݑݑ ݣ ݣݣݣ ࣃ ࣃࣃࣃ ࣄ ࣄࣄࣄ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "End of ayah (ss02)": [
+          {
+            "name": "ss02",
+            "id": "end-of-ayah-(ss02)-label",
+            "default": "0",
+            "label": "‭۝123‬ ‭۝١٢٣‬",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "End of ayah A",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "End of ayah (ss03)": [
+          {
+            "name": "ss03",
+            "id": "end-of-ayah-(ss03)-label",
+            "default": "0",
+            "label": "‭۝123‬ ‭۝١٢٣‬",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "End of ayah B",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Proportional Figures": [
+      {
+        "Proportional Figures for Latin digits": [
+          {
+            "name": "pnum",
+            "id": "proportional-figures-for-latin-digits-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Tabular Figures",
+                "value": "0"
+              },
+              {
+                "tip": "Proportional Figures",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Alkalami Light",
+    "id": "alkalami-light",
+    "Stylistic Sets": [
+      {
+        "Imala e": [
+          {
+            "name": "ss04",
+            "id": "imala-e-label",
+            "default": "0",
+            "label": "بٜ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Jeem/Hah": [
+          {
+            "name": "ss07",
+            "id": "jeem/hah-label",
+            "default": "0",
+            "label": "ج ججج ح ححح خ خخخ ڃ ڃڃڃ ڄ ڄڄڄ ࢢ ࢢࢢࢢ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Flat style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Alef diacritic placement": [
+          {
+            "name": "ss08",
+            "id": "alef-diacritic-placement-label",
+            "default": "0",
+            "label": "اَ اُ اِ باَ باُ باِ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Touching",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Wagaf": [
+          {
+            "name": "ss09",
+            "id": "wagaf-label",
+            "default": "0",
+            "label": "ؿ ؿؿؿ ڟ ڟڟڟ ݑ ݑݑݑ ݣ ݣݣݣ ࣃ ࣃࣃࣃ ࣄ ࣄࣄࣄ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "End of ayah (ss02)": [
+          {
+            "name": "ss02",
+            "id": "end-of-ayah-(ss02)-label",
+            "default": "0",
+            "label": "‭۝123‬ ‭۝١٢٣‬",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "End of ayah A",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "End of ayah (ss03)": [
+          {
+            "name": "ss03",
+            "id": "end-of-ayah-(ss03)-label",
+            "default": "0",
+            "label": "‭۝123‬ ‭۝١٢٣‬",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "End of ayah B",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Proportional Figures": [
+      {
+        "Proportional Figures for Latin digits": [
+          {
+            "name": "pnum",
+            "id": "proportional-figures-for-latin-digits-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Tabular Figures",
+                "value": "0"
+              },
+              {
+                "tip": "Proportional Figures",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Andika",
+    "id": "andika",
+    "Stylistic alternates": [
+      {
+        "Small caps from lowercase": [
+          {
+            "name": "smcp",
+            "id": "small-caps-from-lowercase-label",
+            "default": "0",
+            "label": "a … z",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Small caps from capitals": [
+          {
+            "name": "c2sc",
+            "id": "this-feature-is-not-supported-in-typetuner-web.-label",
+            "default": "0",
+            "label": "A … Z",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Double-story a and g": [
+          {
+            "name": "ss01",
+            "id": "on-typetuner-web-this-feature-is-called-‘single-story-a-and-g’.-it-was-formerly-called-‘literacy-alternates’.-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Double-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Double-story a (only)": [
+          {
+            "name": "ss13",
+            "id": "double-story-a-(only)-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Double-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Double-story g (only)": [
+          {
+            "name": "ss14",
+            "id": "double-story-g-(only)-label",
+            "default": "0",
+            "label": "g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Double-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Barred-bowl forms": [
+          {
+            "name": "ss04",
+            "id": "barred-bowl-forms-label",
+            "default": "0",
+            "label": "đ ƀ ǥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Barred-bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Slant italic specials": [
+          {
+            "name": "ss05",
+            "id": "slant-italic-specials-label",
+            "default": "0",
+            "label": "a ã à á â ä å ā ă ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ạ ặ ⱥ ɐ æ f ḟ i ì í î ï ĩ ī ĭ į ǐ ȉ ȋ ḭ ḯ ỉ ị ı l ĺ ḷ ḹ ḻ ḽ ꝉ ₗ v ṽ ṿ ꝟ z ź ż ž ẑ ẓ ẕ ғ ӻ  fi ffi",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Slanted",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Character alternates": [
+      {
+        "B hook": [
+          {
+            "name": "cv13",
+            "id": "b-hook-label",
+            "default": "0",
+            "label": "Ɓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "D hook": [
+          {
+            "name": "cv17",
+            "id": "d-hook-label",
+            "default": "0",
+            "label": "Ɗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "H stroke": [
+          {
+            "name": "cv28",
+            "id": "h-stroke-label",
+            "default": "0",
+            "label": "Ħ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vertical stroke",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "i": [
+          {
+            "name": "cv31",
+            "id": "i-label",
+            "default": "0",
+            "label": "i ì í î ï ĩ ī ĭ į ı ǐ ȉ ȋ ◌ͥ ᵢ ᶤ ḭ ḭ ḯ ỉ ị ⁱ fi ffi",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Curved tail",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "J": [
+          {
+            "name": "cv35",
+            "id": "j-label",
+            "default": "0",
+            "label": "J Ĵ Ɉ ᴊ ᴶ Ʝ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Bar top",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "J stroke hook": [
+          {
+            "name": "cv37",
+            "id": "j-stroke-hook-label",
+            "default": "0",
+            "label": "ʄ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "l": [
+          {
+            "name": "cv39",
+            "id": "l-label",
+            "default": "0",
+            "label": "l ĺ ļ ľ ŀ ł ƚ ɫ ɬ ˡ ᶅ ᶪ ḷ ḹ ḻ ḽ ⱡ ꝉ ₗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Curved tail",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Eng": [
+          {
+            "name": "cv43",
+            "id": "eng-label",
+            "default": "0",
+            "label": "Ŋ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase style on baseline",
+                "value": "1"
+              },
+              {
+                "tip": "Uppercase style with descender",
+                "value": "2"
+              },
+              {
+                "tip": "Alt. lowercase style on baseline",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "N left hook": [
+          {
+            "name": "cv44",
+            "id": "n-left-hook-label",
+            "default": "0",
+            "label": "Ɲ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Open-O": [
+          {
+            "name": "cv46",
+            "id": "open-o-label",
+            "default": "0",
+            "label": "Ɔ ɔ ᴐ ᵓ ᶗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "OU": [
+          {
+            "name": "cv47",
+            "id": "ou-label",
+            "default": "0",
+            "label": "Ȣ ȣ ᴕ ᴽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Open",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "p hook": [
+          {
+            "name": "cv49",
+            "id": "p-hook-label",
+            "default": "0",
+            "label": "ƥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Q": [
+          {
+            "name": "cv52",
+            "id": "q-label",
+            "default": "0",
+            "label": "Q Ꝗ Ꝙ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Tail across",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "q": [
+          {
+            "name": "cv51",
+            "id": "q-label",
+            "default": "0",
+            "label": "q ꝗ ꝙ ʠ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Pointed",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "R tail": [
+          {
+            "name": "cv55",
+            "id": "r-tail-label",
+            "default": "0",
+            "label": "Ɽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "t": [
+          {
+            "name": "cv56",
+            "id": "t-label",
+            "default": "0",
+            "label": "t ţ ť ŧ ƫ ƭ ț ʇ ʦ ʧ ʨ ◌ͭ ᵗ ᵵ ᵺ ᶵ ṫ ṭ ṯ ṱ ẗ ₜ ⱦ ꜩ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight stem",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "T hook": [
+          {
+            "name": "cv57",
+            "id": "t-hook-label",
+            "default": "0",
+            "label": "Ƭ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "V hook": [
+          {
+            "name": "cv62",
+            "id": "v-hook-label",
+            "default": "0",
+            "label": "Ʋ ʋ ᶹ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight with low hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Y hook": [
+          {
+            "name": "cv68",
+            "id": "y-hook-label",
+            "default": "0",
+            "label": "Ƴ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Left hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "y": [
+          {
+            "name": "cv67",
+            "id": "y-label",
+            "default": "0",
+            "label": "y ɏ ʸ ý ỳ ŷ ẙ ÿ ỹ ẏ ȳ ỷ ỵ ƴ ʎ 𐞡 𝼆",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight tail",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ezh": [
+          {
+            "name": "cv20",
+            "id": "ezh-label",
+            "default": "0",
+            "label": "Ʒ Ӡ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Reversed sigma",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "ezh curl": [
+          {
+            "name": "cv19",
+            "id": "ezh-curl-label",
+            "default": "0",
+            "label": "ʓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "rams horn": [
+          {
+            "name": "cv25",
+            "id": "rams-horn-label",
+            "default": "0",
+            "label": "ɤ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Clicks": [
+          {
+            "name": "cv69",
+            "id": "clicks-label",
+            "default": "0",
+            "label": "ǀ ǁ ǂ ⦀",
+            "Options": [
+              {
+                "tip": "Standard (descending)",
+                "value": "0"
+              },
+              {
+                "tip": "Baseline",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Diacritic and symbol alternates": [
+      {
+        "Vietnamese-style diacritics": [
+          {
+            "name": "cv75",
+            "id": "vietnamese-style-diacritics-label",
+            "default": "0",
+            "label": "Ấấ Ầầ Ẩẩ Ẫẫ Ắắ Ằằ Ẳẳ Ẵẵ Ếế Ềề Ểể Ễễ Ốố Ồồ Ổổ Ỗỗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vietnamese-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Kayan diacritics": [
+          {
+            "name": "cv79",
+            "id": "kayan-diacritics-label",
+            "default": "0",
+            "label": "◌̀́",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Side by side",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ogonek": [
+          {
+            "name": "cv76",
+            "id": "ogonek-label",
+            "default": "0",
+            "label": "anything with ◌̨ (Ąą Ęę Įį Ųų Ǫǫ Ǭǭ)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Caron": [
+          {
+            "name": "cv77",
+            "id": "caron-label",
+            "default": "0",
+            "label": "ď Ľ ľ ť",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Global-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier apostrophe": [
+          {
+            "name": "cv70",
+            "id": "modifier-apostrophe-label",
+            "default": "0",
+            "label": "ʼ Ꞌ ꞌ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier colon": [
+          {
+            "name": "cv71",
+            "id": "modifier-colon-label",
+            "default": "0",
+            "label": "꞉",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Expanded",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Empty set": [
+          {
+            "name": "cv98",
+            "id": "empty-set-label",
+            "default": "0",
+            "label": "∅",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Zero-style",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Cyrillic alternates": [
+      {
+        "Cyrillic E": [
+          {
+            "name": "cv80",
+            "id": "cyrillic-e-label",
+            "default": "0",
+            "label": "Э э",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Mongolian-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic shha": [
+          {
+            "name": "cv81",
+            "id": "cyrillic-shha-label",
+            "default": "0",
+            "label": "һ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Uppercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic breve": [
+          {
+            "name": "cv82",
+            "id": "cyrillic-breve-label",
+            "default": "0",
+            "label": "anything with ◌̆ (Ә̆ә̆)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Cyrillic-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Serbian and Macedonian Cyrillic alternates": [
+          {
+            "name": "cv84",
+            "id": "serbian-and-macedonian-cyrillic-alternates-label",
+            "default": "0",
+            "label": "б г д п т ѓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Serbian Macedonian forms",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Tone alternates": [
+      {
+        "Chinantec tones": [
+          {
+            "name": "cv90",
+            "id": "chinantec-tones-label",
+            "default": "0",
+            "label": "ˋ ˈ ˉ ˊ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Chinantec-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Tone numbers": [
+          {
+            "name": "cv91",
+            "id": "tone-numbers-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Numbers",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Hide tone contour staves": [
+          {
+            "name": "cv92",
+            "id": "hide-tone-contour-staves-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖ (˩˦˥˧˨ ꜖꜓꜒꜔꜕)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Hide staves",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Numeral alternates": [
+      {
+        "Subscript numerals": [
+          {
+            "name": "subs",
+            "id": "subscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Subscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Superscript numerals": [
+          {
+            "name": "sups",
+            "id": "superscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Superscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Automatic fractions": [
+          {
+            "name": "frac",
+            "id": "automatic-fractions-label",
+            "default": "0",
+            "label": "1⁄2 456⁄789 1/2 456/789",
+            "Options": [
+              {
+                "tip": "Standard (none)",
+                "value": "0"
+              },
+              {
+                "tip": "Automatic",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "0": [
+          {
+            "name": "cv10",
+            "id": "0-label",
+            "default": "0",
+            "label": "0 ⁰ ₀ ⅒ ↉",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Slashed",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "1": [
+          {
+            "name": "cv01",
+            "id": "1-label",
+            "default": "0",
+            "label": "1 ¹ ¼ ½ ₁ ⅐ ⅑ ⅒ ⅓ ⅕ ⅙ ⅛",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "No Base Serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "4": [
+          {
+            "name": "cv04",
+            "id": "4-label",
+            "default": "0",
+            "label": "4 ¼ ¾ ⁴ ₄ ⅘",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Open",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "6 and 9": [
+          {
+            "name": "cv06",
+            "id": "6-and-9-label",
+            "default": "0",
+            "label": "6 9 ⁶ ⁹ ₆ ₉ ⅑ ⅙ ⅚",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Diagonal stem",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "7": [
+          {
+            "name": "cv07",
+            "id": "7-label",
+            "default": "0",
+            "label": "7 ⁷ ₇ ⅐ ⅞",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Barred",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Annapurna SIL",
+    "id": "annapurna-sil",
+    "User-selected features": [
+      {
+        "Jha alternates": [
+          {
+            "name": "cv01",
+            "id": "jha-alternates-label",
+            "default": "0",
+            "label": "झ झ् झ़ झ़् झ्र झ़्र",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Nepali style",
+                "value": "1"
+              },
+              {
+                "tip": "Newari style",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Kra alternate": [
+          {
+            "name": "cv03",
+            "id": "kra-alternate-label",
+            "default": "0",
+            "label": "क्र क़्र",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Open style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Tra alternate": [
+          {
+            "name": "cv04",
+            "id": "tra-alternate-label",
+            "default": "0",
+            "label": "त्र त़्र",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Closed style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Shra alternate": [
+          {
+            "name": "cv05",
+            "id": "shra-alternate-label",
+            "default": "0",
+            "label": "श्र श़्र",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Sha style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ukar nukta position": [
+          {
+            "name": "cv06",
+            "id": "ukar-nukta-position-label",
+            "default": "0",
+            "label": "कु़ कू़ क्कु़ क्कू़",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Outside",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ekar nukta position": [
+          {
+            "name": "cv07",
+            "id": "ekar-nukta-position-label",
+            "default": "0",
+            "label": "के़",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Above bar",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Digit five alternate": [
+          {
+            "name": "cv08",
+            "id": "digit-five-alternate-label",
+            "default": "0",
+            "label": "5",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Nepali style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Digit eight alternate": [
+          {
+            "name": "cv09",
+            "id": "digit-eight-alternate-label",
+            "default": "0",
+            "label": "8",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Nepali style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Digit nine alternates": [
+          {
+            "name": "cv10",
+            "id": "digit-nine-alternates-label",
+            "default": "0",
+            "label": "9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Nepali style",
+                "value": "1"
+              },
+              {
+                "tip": "Newari style",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Visarga with connecting bar": [
+          {
+            "name": "cv12",
+            "id": "visarga-with-connecting-bar-label",
+            "default": "0",
+            "label": "ः",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "With bar",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Glottal stop - no connecting bar": [
+          {
+            "name": "cv13",
+            "id": "glottal-stop---no-connecting-bar-label",
+            "default": "0",
+            "label": "ॽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "No bar",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Dya and Hya alternates": [
+          {
+            "name": "cv14",
+            "id": "dya-and-hya-alternates-label",
+            "default": "0",
+            "label": "द्य द्य् द्य़ द्य़् द्य्र द्य़्र ह्य ह्य् ह्य़ ह्य़् ह्य्र ह्य़्र",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Open Ya",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Archaic forms": [
+          {
+            "name": "cv15",
+            "id": "archaic-forms-label",
+            "default": "0",
+            "label": "अ आ ओ औ ण ण् क्ष क्ष्",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Archaic form",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ra Ukar with Nukta ligatures": [
+          {
+            "name": "cv16",
+            "id": "ra-ukar-with-nukta-ligatures-label",
+            "default": "0",
+            "label": "रु़ ऱु़ रू़ ऱू़",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Ligature form",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cha alternate": [
+          {
+            "name": "cv17",
+            "id": "cha-alternate-label",
+            "default": "0",
+            "label": "छ छ्",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "With tail or no stem",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Headstroke alternates": [
+          {
+            "name": "cv21",
+            "id": "headstroke-alternates-label",
+            "default": "0",
+            "label": "ꣻ कꣻम",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Discrete",
+                "value": "1"
+              },
+              {
+                "tip": "Narrow",
+                "value": "2"
+              },
+              {
+                "tip": "Filler (zero advance width)",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "JainOm alternate": [
+          {
+            "name": "cv22",
+            "id": "jainom-alternate-label",
+            "default": "0",
+            "label": "ꣽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Extended headstroke",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Numeral alternates": [
+      {
+        "Fractions": [
+          {
+            "name": "frac",
+            "id": "fractions-label",
+            "default": 1,
+            "label": "१⁄२ १⁄४ ३⁄४",
+            "Options": [
+              {
+                "tip": "Fractions",
+                "value": 1
+              },
+              {
+                "tip": "No ligature (use ZWNJ)",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Awami Nastaliq",
+    "id": "awami-nastaliq",
+    "Character variants": [
+      {
+        "Hook on medial heh-goal": [
+          {
+            "name": "hehk",
+            "id": "hook-on-medial-heh-goal-label",
+            "default": "1",
+            "label": "ب<font color={fontColor}>ہ</font>ب ب<font color={fontColor}>ۂ</font>ب",
+            "Options": [
+              {
+                "tip": "Yes",
+                "value": "1"
+              },
+              {
+                "tip": "No",
+                "value": "0"
+              }
+            ]
+          }
+        ],
+        "Initial heh doachashmee": [
+            {
+            "name": "hedo",
+            "id": "initial-heh-doachashmee-label",
+            "default": "0",
+            "label": "<font color={fontColor}>ھ</font>ا",
+            "Options": [
+              {
+                "tip": "Heart shaped",
+                "value": "0"
+              },
+              {
+                "tip": "Round",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Lam with V": [
+            {
+            "name": "lamv",
+            "id": "lam-with-v-label",
+            "default": "0",
+            "label": "<font color={fontColor}>ڵ</font> ڵبڵب<font color={fontColor}>ڵ</font>",
+            "Options": [
+              {
+                "tip": "V over stem",
+                "value": "0"
+              },
+              {
+                "tip": "V over bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Full Stop": [
+            {
+            "name": "cv85",
+            "id": "full-stop-label",
+            "default": "0",
+            "label": "ججج<font color={fontColor}>۔</font>",
+            "Options": [
+              {
+                "tip": "Dash",
+                "value": "0"
+              },
+              {
+                "tip": "Dot",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Sukun/jazm": [
+            {
+            "name": "cv78",
+            "id": "sukun-jazm-label",
+            "default": "1",
+            "label": "بْ ◌ْ",
+            "Options": [
+              {
+                "tip": "Open down",
+                "value": "1"
+              },
+              {
+                "tip": "Open left",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Hamza": [
+            {
+            "name": "hamz",
+            "id": "hamza-label",
+            "default": "0",
+            "label": "ء أ ؤ بؤ إ ۂ بۂ ۓ بۓ ٵ ݬ بݬ ځ بځ بځب بٔ بٕ",
+            "Options": [
+              {
+                "tip": "Urdu style",
+                "value": "0"
+              },
+              {
+                "tip": "Arabic style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Word spacing": [
+            {
+            "name": "wdsp",
+            "id": "word-spacing-label",
+            "default": "2",
+            "label": "کیوں جو انسانی حقوق کنوں",
+            "Options": [
+              {
+                "tip": "Extra tight",
+                "value": "0"
+              },
+              {
+                "tip": "Tight",
+                "value": "1"
+              },
+              {
+                "tip": "Medium",
+                "value": "2"
+              },
+              {
+                "tip": "Wide",
+                "value": "3"
+              },
+              {
+                "tip": "Extra wide",
+                "value": "4"
+              }
+            ]
+          }
+        ],
+        "Collision avoidance": [
+            {
+            "name": "agca",
+            "id": "collision-avoidance-label",
+            "default": "3",
+            "label": "<font color={fontColor}>پی</font>ٹی <font color={fontColor}>اؔبِی</font>ج<font color={fontColor}>یل</font> تح<font color={fontColor}>ر</font>ِ<font color={fontColor}>ی</font>ج",
+            "Options": [
+              {
+                "tip": "On",
+                "value": "3"
+              },
+              {
+                "tip": "Kern-only",
+                "value": "1"
+              },
+              {
+                "tip": "Off",
+                "value": "0"
+              }
+            ]
+          }
+        ],
+        "Short forms": [
+            {
+            "name": "shrt",
+            "id": "short-forms-label",
+            "default": "3",
+            "label": "دی<font color={fontColor}>ک</font>ھت<font color={fontColor}>ی</font> <font color={fontColor}>ک</font>نسلٹنٹ<font color={fontColor}>س</font> ن<font color={fontColor}>گ</font>ھنے ت<font color={fontColor}>ک</font>می<font color={fontColor}>ل</font>",
+            "Options": [
+              {
+                "tip": "All",
+                "value": "3"
+              },
+              {
+                "tip": "Finals",
+                "value": "2"
+              },
+              {
+                "tip": "Kafs and gafs",
+                "value": "1"
+              },
+              {
+                "tip": "None",
+                "value": "0"
+              }
+            ]
+          }
+        ],
+        "Punctuation": [
+            {
+            "name": "punc",
+            "id": "punctuation-label",
+            "default": "0",
+            "label": "! &quot; &apos; ( ) * + - / : [  ] { } « ­ ± · » ×   ‐ ‑ ‒ – — ― ‘ ’ ‚ “ ” „ • ‥ … ‧ ‰ ‹ › − ∙ ",
+            "Options": [
+              {
+                "tip": "Arabic (RTL) and Latin (LTR) styles",
+                "value": "0"
+              },
+              {
+                "tip": "Arabic-style",
+                "value": "1"
+              },
+              {
+                "tip": "Latin-style",
+                "value": "2"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Charis SIL",
+    "id": "charis-sil",
+    "Stylistic alternates": [
+      {
+        "Small caps from lowercase": [
+          {
+            "name": "smcp",
+            "id": "small-caps-from-lowercase-label",
+            "default": "0",
+            "label": "a … z (all letters with capital equivalents)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Small caps from capitals": [
+          {
+            "name": "c2sc",
+            "id": "small-caps-from-capitals-label",
+            "default": "0",
+            "label": "A … Z (all capitals)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story a and g": [
+          {
+            "name": "ss01",
+            "id": "single-story-a-and-g-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story a (only)": [
+          {
+            "name": "ss11",
+            "id": "single-story-a-(only)-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story g (only)": [
+          {
+            "name": "ss12",
+            "id": "single-story-g-(only)-label",
+            "default": "0",
+            "label": "g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Barred-bowl forms": [
+          {
+            "name": "ss04",
+            "id": "barred-bowl-forms-label",
+            "default": "0",
+            "label": "đ ƀ ǥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Barred-bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Slant italic specials": [
+          {
+            "name": "ss05",
+            "id": "slant-italic-specials-label",
+            "default": "0",
+            "label": "a ã à á â ä å ā ă ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ạ ặ ⱥ ɐ æ f ḟ i ì í î ï ĩ ī ĭ į ǐ ȉ ȋ ḭ ḯ ỉ ị ı l ĺ ḷ ḹ ḻ ḽ ꝉ ₗ v ṽ ṿ ꝟ z ź ż ž ẑ ẓ ẕ ғ ӻ  fi ffi",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Slanted",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Character alternates": [
+      {
+        "B hook": [
+          {
+            "name": "cv13",
+            "id": "b-hook-label",
+            "default": "0",
+            "label": "Ɓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "D hook": [
+          {
+            "name": "cv17",
+            "id": "d-hook-label",
+            "default": "0",
+            "label": "Ɗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "H stroke": [
+          {
+            "name": "cv28",
+            "id": "h-stroke-label",
+            "default": "0",
+            "label": "Ħ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vertical stroke",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "J stroke hook": [
+          {
+            "name": "cv37",
+            "id": "j-stroke-hook-label",
+            "default": "0",
+            "label": "ʄ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Eng": [
+          {
+            "name": "cv43",
+            "id": "eng-label",
+            "default": "0",
+            "label": "Ŋ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase style on baseline",
+                "value": "1"
+              },
+              {
+                "tip": "Uppercase style with descender",
+                "value": "2"
+              },
+              {
+                "tip": "Alt. lowercase style on baseline",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "N left hook": [
+          {
+            "name": "cv44",
+            "id": "n-left-hook-label",
+            "default": "0",
+            "label": "Ɲ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Open-O": [
+          {
+            "name": "cv46",
+            "id": "open-o-label",
+            "default": "0",
+            "label": "Ɔ ɔ ᴐ ᵓ ᶗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "OU": [
+          {
+            "name": "cv47",
+            "id": "ou-label",
+            "default": "0",
+            "label": "Ȣ ȣ ᴕ ᴽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Open",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "p hook": [
+          {
+            "name": "cv49",
+            "id": "p-hook-label",
+            "default": "0",
+            "label": "ƥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "R tail": [
+          {
+            "name": "cv55",
+            "id": "r-tail-label",
+            "default": "0",
+            "label": "Ɽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "T hook": [
+          {
+            "name": "cv57",
+            "id": "t-hook-label",
+            "default": "0",
+            "label": "Ƭ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "V hook": [
+          {
+            "name": "cv62",
+            "id": "v-hook-label",
+            "default": "0",
+            "label": "Ʋ ʋ ᶹ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight with low hook",
+                "value": "1"
+              },
+              {
+                "tip": "Straight with high hook",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Y hook": [
+          {
+            "name": "cv68",
+            "id": "y-hook-label",
+            "default": "0",
+            "label": "Ƴ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Left hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ezh": [
+          {
+            "name": "cv20",
+            "id": "ezh-label",
+            "default": "0",
+            "label": "Ʒ Ӡ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Reversed sigma",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "ezh curl": [
+          {
+            "name": "cv19",
+            "id": "ezh-curl-label",
+            "default": "0",
+            "label": "ʓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "rams horn": [
+          {
+            "name": "cv25",
+            "id": "rams-horn-label",
+            "default": "0",
+            "label": "ɤ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              },
+              {
+                "tip": "Small gamma",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Clicks": [
+          {
+            "name": "cv69",
+            "id": "clicks-label",
+            "default": "0",
+            "label": "ǀ ǁ ǂ ⦀",
+            "Options": [
+              {
+                "tip": "Standard (descending)",
+                "value": "0"
+              },
+              {
+                "tip": "Baseline",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Diacritic and symbol alternates": [
+      {
+        "Vietnamese-style diacritics": [
+          {
+            "name": "cv75",
+            "id": "vietnamese-style-diacritics-label",
+            "default": "0",
+            "label": "Ấấ Ầầ Ẩẩ Ẫẫ Ắắ Ằằ Ẳẳ Ẵẵ Ếế Ềề Ểể Ễễ Ốố Ồồ Ổổ Ỗỗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vietnamese-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Kayan diacritics": [
+          {
+            "name": "cv79",
+            "id": "kayan-diacritics-label",
+            "default": "0",
+            "label": "◌̀́",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Side by side",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ogonek": [
+          {
+            "name": "cv76",
+            "id": "ogonek-label",
+            "default": "0",
+            "label": "anything with ◌̨ (Ąą Ęę Įį Ųų Ǫǫ Ǭǭ)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Caron": [
+          {
+            "name": "cv77",
+            "id": "caron-label",
+            "default": "0",
+            "label": "ď Ľ ľ ť",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Global-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier apostrophe": [
+          {
+            "name": "cv70",
+            "id": "modifier-apostrophe-label",
+            "default": "0",
+            "label": "ʼ Ꞌ ꞌ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier colon": [
+          {
+            "name": "cv71",
+            "id": "modifier-colon-label",
+            "default": "0",
+            "label": "꞉",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Expanded",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Empty set": [
+          {
+            "name": "cv98",
+            "id": "empty-set-label",
+            "default": "0",
+            "label": "∅",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Zero-style",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Cyrillic alternates": [
+      {
+        "Cyrillic E": [
+          {
+            "name": "cv80",
+            "id": "cyrillic-e-label",
+            "default": "0",
+            "label": "Э э",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Mongolian-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic shha": [
+          {
+            "name": "cv81",
+            "id": "cyrillic-shha-label",
+            "default": "0",
+            "label": "һ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Uppercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic breve": [
+          {
+            "name": "cv82",
+            "id": "cyrillic-breve-label",
+            "default": "0",
+            "label": "anything with ◌̆ (Ә̆ә̆)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Cyrillic-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Serbian and Macedonian Cyrillic alternates": [
+          {
+            "name": "cv84",
+            "id": "serbian-and-macedonian-cyrillic-alternates-label",
+            "default": "0",
+            "label": "б г д п т ѓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Serbian Macedonian forms",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Tone alternates": [
+      {
+        "Chinantec tones": [
+          {
+            "name": "cv90",
+            "id": "chinantec-tones-label",
+            "default": "0",
+            "label": "ˋ ˈ ˉ ˊ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Chinantec-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Tone numbers": [
+          {
+            "name": "cv91",
+            "id": "tone-numbers-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Numbers",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Hide tone contour staves": [
+          {
+            "name": "cv92",
+            "id": "hide-tone-contour-staves-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖ (˩˦˥˧˨ ꜖꜓꜒꜔꜕)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Hide staves",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Numeral alternates": [
+      {
+        "Subscript numerals": [
+          {
+            "name": "subs",
+            "id": "subscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Subscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Superscript numerals": [
+          {
+            "name": "sups",
+            "id": "superscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Superscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Automatic fractions": [
+          {
+            "name": "frac",
+            "id": "automatic-fractions-label",
+            "default": "0",
+            "label": "1⁄2 456⁄789 1/2 456/789",
+            "Options": [
+              {
+                "tip": "Standard (none)",
+                "value": "0"
+              },
+              {
+                "tip": "Automatic",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Doulos SIL",
+    "id": "doulos-sil",
+    "Stylistic alternates": [
+      {
+        "Small caps from lowercase": [
+          {
+            "name": "smcp",
+            "id": "small-caps-from-lowercase-label",
+            "default": "0",
+            "label": "a … z (all letters with capital equivalents)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Small caps from capitals": [
+          {
+            "name": "c2sc",
+            "id": "small-caps-from-capitals-label",
+            "default": "0",
+            "label": "A … Z (all capitals)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story a and g": [
+          {
+            "name": "ss01",
+            "id": "single-story-a-and-g-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story a (only)": [
+          {
+            "name": "ss11",
+            "id": "single-story-a-(only)-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story g (only)": [
+          {
+            "name": "ss12",
+            "id": "single-story-g-(only)-label",
+            "default": "0",
+            "label": "g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Barred-bowl forms": [
+          {
+            "name": "ss04",
+            "id": "barred-bowl-forms-label",
+            "default": "0",
+            "label": "đ ƀ ǥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Barred-bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Character alternates": [
+      {
+        "B hook": [
+          {
+            "name": "cv13",
+            "id": "b-hook-label",
+            "default": "0",
+            "label": "Ɓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "D hook": [
+          {
+            "name": "cv17",
+            "id": "d-hook-label",
+            "default": "0",
+            "label": "Ɗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "H stroke": [
+          {
+            "name": "cv28",
+            "id": "h-stroke-label",
+            "default": "0",
+            "label": "Ħ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vertical stroke",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "J stroke hook": [
+          {
+            "name": "cv37",
+            "id": "j-stroke-hook-label",
+            "default": "0",
+            "label": "ʄ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Eng": [
+          {
+            "name": "cv43",
+            "id": "eng-label",
+            "default": "0",
+            "label": "Ŋ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase style on baseline",
+                "value": "1"
+              },
+              {
+                "tip": "Uppercase style with descender",
+                "value": "2"
+              },
+              {
+                "tip": "Alt. lowercase style on baseline",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "N left hook": [
+          {
+            "name": "cv44",
+            "id": "n-left-hook-label",
+            "default": "0",
+            "label": "Ɲ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Open-O": [
+          {
+            "name": "cv46",
+            "id": "open-o-label",
+            "default": "0",
+            "label": "Ɔ ɔ ᴐ ᵓ ᶗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "OU": [
+          {
+            "name": "cv47",
+            "id": "ou-label",
+            "default": "0",
+            "label": "Ȣ ȣ ᴕ ᴽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Open",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "p hook": [
+          {
+            "name": "cv49",
+            "id": "p-hook-label",
+            "default": "0",
+            "label": "ƥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "R tail": [
+          {
+            "name": "cv55",
+            "id": "r-tail-label",
+            "default": "0",
+            "label": "Ɽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "T hook": [
+          {
+            "name": "cv57",
+            "id": "t-hook-label",
+            "default": "0",
+            "label": "Ƭ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "V hook": [
+          {
+            "name": "cv62",
+            "id": "v-hook-label",
+            "default": "0",
+            "label": "Ʋ ʋ ᶹ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight with low hook",
+                "value": "1"
+              },
+              {
+                "tip": "Straight with high hook",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Y hook": [
+          {
+            "name": "cv68",
+            "id": "y-hook-label",
+            "default": "0",
+            "label": "Ƴ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Left hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ezh": [
+          {
+            "name": "cv20",
+            "id": "ezh-label",
+            "default": "0",
+            "label": "Ʒ Ӡ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Reversed sigma",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "ezh curl": [
+          {
+            "name": "cv19",
+            "id": "ezh-curl-label",
+            "default": "0",
+            "label": "ʓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "rams horn": [
+          {
+            "name": "cv25",
+            "id": "rams-horn-label",
+            "default": "0",
+            "label": "ɤ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              },
+              {
+                "tip": "Small gamma",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Clicks": [
+          {
+            "name": "cv69",
+            "id": "clicks-label",
+            "default": "0",
+            "label": "ǀ ǁ ǂ ⦀",
+            "Options": [
+              {
+                "tip": "Standard (descending)",
+                "value": "0"
+              },
+              {
+                "tip": "Baseline",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Diacritic and symbol alternates": [
+      {
+        "Vietnamese-style diacritics": [
+          {
+            "name": "cv75",
+            "id": "vietnamese-style-diacritics-label",
+            "default": "0",
+            "label": "Ấấ Ầầ Ẩẩ Ẫẫ Ắắ Ằằ Ẳẳ Ẵẵ Ếế Ềề Ểể Ễễ Ốố Ồồ Ổổ Ỗỗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vietnamese-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Kayan diacritics": [
+          {
+            "name": "cv79",
+            "id": "kayan-diacritics-label",
+            "default": "0",
+            "label": "◌̀́",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Side by side",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ogonek": [
+          {
+            "name": "cv76",
+            "id": "ogonek-label",
+            "default": "0",
+            "label": "anything with ◌̨ (Ąą Ęę Įį Ųų Ǫǫ Ǭǭ)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Caron": [
+          {
+            "name": "cv77",
+            "id": "caron-label",
+            "default": "0",
+            "label": "ď Ľ ľ ť",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Global-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier apostrophe": [
+          {
+            "name": "cv70",
+            "id": "modifier-apostrophe-label",
+            "default": "0",
+            "label": "ʼ Ꞌ ꞌ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier colon": [
+          {
+            "name": "cv71",
+            "id": "modifier-colon-label",
+            "default": "0",
+            "label": "꞉",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Expanded",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Empty set": [
+          {
+            "name": "cv98",
+            "id": "empty-set-label",
+            "default": "0",
+            "label": "∅",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Zero-style",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Cyrillic alternates": [
+      {
+        "Cyrillic E": [
+          {
+            "name": "cv80",
+            "id": "cyrillic-e-label",
+            "default": "0",
+            "label": "Э э",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Mongolian-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic shha": [
+          {
+            "name": "cv81",
+            "id": "cyrillic-shha-label",
+            "default": "0",
+            "label": "һ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Uppercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic breve": [
+          {
+            "name": "cv82",
+            "id": "cyrillic-breve-label",
+            "default": "0",
+            "label": "anything with ◌̆ (Ә̆ә̆)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Cyrillic-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Serbian and Macedonian Cyrillic alternates": [
+          {
+            "name": "cv84",
+            "id": "serbian-and-macedonian-cyrillic-alternates-label",
+            "default": "0",
+            "label": "б",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Serbian Macedonian forms",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Tone alternates": [
+      {
+        "Chinantec tones": [
+          {
+            "name": "cv90",
+            "id": "chinantec-tones-label",
+            "default": "0",
+            "label": "ˋ ˈ ˉ ˊ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Chinantec-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Tone numbers": [
+          {
+            "name": "cv91",
+            "id": "tone-numbers-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Numbers",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Hide tone contour staves": [
+          {
+            "name": "cv92",
+            "id": "hide-tone-contour-staves-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖ (˩˦˥˧˨ ꜖꜓꜒꜔꜕)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Hide staves",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Numeral alternates": [
+      {
+        "Subscript numerals": [
+          {
+            "name": "subs",
+            "id": "subscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Subscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Superscript numerals": [
+          {
+            "name": "sups",
+            "id": "superscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Superscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Automatic fractions": [
+          {
+            "name": "frac",
+            "id": "automatic-fractions-label",
+            "default": "0",
+            "label": "1⁄2 456⁄789 1/2 456/789",
+            "Options": [
+              {
+                "tip": "Standard (none)",
+                "value": "0"
+              },
+              {
+                "tip": "Automatic",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Gentium Plus",
+    "id": "gentium-plus",
+    "Stylistic alternates": [
+      {
+        "Small caps from lowercase": [
+          {
+            "name": "smcp",
+            "id": "small-caps-from-lowercase-label",
+            "default": "0",
+            "label": "a … z (all letters with capital equivalents)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Small caps from capitals": [
+          {
+            "name": "c2sc",
+            "id": "small-caps-from-capitals-label",
+            "default": "0",
+            "label": "A … Z (all capitals)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small caps",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story a and g": [
+          {
+            "name": "ss01",
+            "id": "single-story-a-and-g-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story a (only)": [
+          {
+            "name": "ss11",
+            "id": "single-story-a-(only)-label",
+            "default": "0",
+            "label": "a ª à á â ã ä å ā ă ą ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ạ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ặ ⱥ ₐ ᵃ ◌ͣ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Single-story g (only)": [
+          {
+            "name": "ss12",
+            "id": "single-story-g-(only)-label",
+            "default": "0",
+            "label": "g ĝ ğ ġ ģ ǧ ǵ ǥ ḡ ꞡ ᵍ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Single-story",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Barred-bowl forms": [
+          {
+            "name": "ss04",
+            "id": "barred-bowl-forms-label",
+            "default": "0",
+            "label": "đ ƀ ǥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Barred-bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Slant italic specials": [
+          {
+            "name": "ss05",
+            "id": "slant-italic-specials-label",
+            "default": "0",
+            "label": "a ã à á â ä å ā ă ǎ ǟ ǡ ǻ ȁ ȃ ȧ ḁ ẚ ả ấ ầ ẩ ẫ ậ ắ ằ ẳ ẵ ạ ặ ⱥ ɐ æ f ḟ i ì í î ï ĩ ī ĭ į ǐ ȉ ȋ ḭ ḯ ỉ ị ı l ĺ ḷ ḹ ḻ ḽ ꝉ ₗ v ṽ ṿ ꝟ z ź ż ž ẑ ẓ ẕ ғ ӻ  fi ffi",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Slanted",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Character alternates": [
+      {
+        "B hook": [
+          {
+            "name": "cv13",
+            "id": "b-hook-label",
+            "default": "0",
+            "label": "Ɓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "D hook": [
+          {
+            "name": "cv17",
+            "id": "d-hook-label",
+            "default": "0",
+            "label": "Ɗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "H stroke": [
+          {
+            "name": "cv28",
+            "id": "h-stroke-label",
+            "default": "0",
+            "label": "Ħ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vertical stroke",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "J stroke hook": [
+          {
+            "name": "cv37",
+            "id": "j-stroke-hook-label",
+            "default": "0",
+            "label": "ʄ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Eng": [
+          {
+            "name": "cv43",
+            "id": "eng-label",
+            "default": "0",
+            "label": "Ŋ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase style on baseline",
+                "value": "1"
+              },
+              {
+                "tip": "Uppercase style with descender",
+                "value": "2"
+              },
+              {
+                "tip": "Alt. lowercase style on baseline",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "N left hook": [
+          {
+            "name": "cv44",
+            "id": "n-left-hook-label",
+            "default": "0",
+            "label": "Ɲ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Open-O": [
+          {
+            "name": "cv46",
+            "id": "open-o-label",
+            "default": "0",
+            "label": "Ɔ ɔ ᴐ ᵓ ᶗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Top serif",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "OU": [
+          {
+            "name": "cv47",
+            "id": "ou-label",
+            "default": "0",
+            "label": "Ȣ ȣ ᴕ ᴽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Open",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "p hook": [
+          {
+            "name": "cv49",
+            "id": "p-hook-label",
+            "default": "0",
+            "label": "ƥ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "R tail": [
+          {
+            "name": "cv55",
+            "id": "r-tail-label",
+            "default": "0",
+            "label": "Ɽ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Lowercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "T hook": [
+          {
+            "name": "cv57",
+            "id": "t-hook-label",
+            "default": "0",
+            "label": "Ƭ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "V hook": [
+          {
+            "name": "cv62",
+            "id": "v-hook-label",
+            "default": "0",
+            "label": "Ʋ ʋ ᶹ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight with low hook",
+                "value": "1"
+              },
+              {
+                "tip": "Straight with high hook",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Y hook": [
+          {
+            "name": "cv68",
+            "id": "y-hook-label",
+            "default": "0",
+            "label": "Ƴ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Left hook",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ezh": [
+          {
+            "name": "cv20",
+            "id": "ezh-label",
+            "default": "0",
+            "label": "Ʒ Ӡ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Reversed sigma",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "ezh curl": [
+          {
+            "name": "cv19",
+            "id": "ezh-curl-label",
+            "default": "0",
+            "label": "ʓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "rams horn": [
+          {
+            "name": "cv25",
+            "id": "rams-horn-label",
+            "default": "0",
+            "label": "ɤ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large bowl",
+                "value": "1"
+              },
+              {
+                "tip": "Small gamma",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Clicks": [
+          {
+            "name": "cv69",
+            "id": "clicks-label",
+            "default": "0",
+            "label": "ǀ ǁ ǂ ⦀",
+            "Options": [
+              {
+                "tip": "Standard (descending)",
+                "value": "0"
+              },
+              {
+                "tip": "Baseline",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Diacritic and symbol alternates": [
+      {
+        "Low-profile diacritics": [
+          {
+            "name": "ss07",
+            "id": "low-profile-diacritics-label",
+            "default": "0",
+            "label": "anything with ◌́◌̀◌̂◌̌◌̄◌̃◌̈◌̇ (áàâǎāãäȧ)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Low-profile",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Vietnamese-style diacritics": [
+          {
+            "name": "cv75",
+            "id": "vietnamese-style-diacritics-label",
+            "default": "0",
+            "label": "Ấấ Ầầ Ẩẩ Ẫẫ Ắắ Ằằ Ẳẳ Ẵẵ Ếế Ềề Ểể Ễễ Ốố Ồồ Ổổ Ỗỗ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Vietnamese-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Kayan diacritics": [
+          {
+            "name": "cv79",
+            "id": "kayan-diacritics-label",
+            "default": "0",
+            "label": "◌̀́",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Side by side",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ogonek": [
+          {
+            "name": "cv76",
+            "id": "ogonek-label",
+            "default": "0",
+            "label": "anything with ◌̨ (Ąą Ęę Įį Ųų Ǫǫ Ǭǭ)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Straight",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Caron": [
+          {
+            "name": "cv77",
+            "id": "caron-label",
+            "default": "0",
+            "label": "ď Ľ ľ ť",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Global-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier apostrophe": [
+          {
+            "name": "cv70",
+            "id": "modifier-apostrophe-label",
+            "default": "0",
+            "label": "ʼ Ꞌ ꞌ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Modifier colon": [
+          {
+            "name": "cv71",
+            "id": "modifier-colon-label",
+            "default": "0",
+            "label": "꞉",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Expanded",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Empty set": [
+          {
+            "name": "cv98",
+            "id": "empty-set-label",
+            "default": "0",
+            "label": "∅",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Zero-style",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Cyrillic alternates": [
+      {
+        "Cyrillic E": [
+          {
+            "name": "cv80",
+            "id": "cyrillic-e-label",
+            "default": "0",
+            "label": "Э э",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Mongolian-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic shha": [
+          {
+            "name": "cv81",
+            "id": "cyrillic-shha-label",
+            "default": "0",
+            "label": "һ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Uppercase-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Cyrillic breve": [
+          {
+            "name": "cv82",
+            "id": "cyrillic-breve-label",
+            "default": "0",
+            "label": "anything with ◌̆ (Ә̆ә̆)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Cyrillic-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Serbian and Macedonian Cyrillic alternates": [
+          {
+            "name": "cv84",
+            "id": "serbian-and-macedonian-cyrillic-alternates-label",
+            "default": "0",
+            "label": "б г д п т ѓ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Serbian Macedonian forms",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Greek alternates": [
+      {
+        "Porsonic circumflex": [
+          {
+            "name": "cv78",
+            "id": "porsonic-circumflex-label",
+            "default": "0",
+            "label": "◌͂ ◌῀ ◌῁ ◌῏ ◌῟ ἆ ἇ ᾆ ᾇ ᾶ ᾷ ἦ ἧ ᾖ ᾗ ῆ ῇ ἶ ἷ ῖ ῗ ὖ ὗ ῦ ῧ ὦ ὧ ᾦ ᾧ ῶ ῷ Ἆ Ἇ ᾎ ᾏ Ἦ Ἧ ᾞ ᾟ Ἶ Ἷ Ὗ Ὦ Ὧ ᾮ ᾯ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Porsonic-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Capital adscript iota (prosgegrammeni)": [
+          {
+            "name": "cv83",
+            "id": "capital-adscript-iota-(prosgegrammeni)-label",
+            "default": "0",
+            "label": "ᾼ ᾈ ᾉ ᾊ ᾋ ᾌ ᾍ ᾎ ᾏ ῌ ᾘ ᾙ ᾚ ᾛ ᾜ ᾝ ᾞ ᾟ ῼ ᾨ ᾩ ᾪ ᾫ ᾬ ᾭ ᾮ ᾯ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Subscript (ypogegrammeni)",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "beta": [
+          {
+            "name": "cv14",
+            "id": "beta-label",
+            "default": "0",
+            "label": "β ᵝ ᵦ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "With serifs",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Tone alternates": [
+      {
+        "Chinantec tones": [
+          {
+            "name": "cv90",
+            "id": "chinantec-tones-label",
+            "default": "0",
+            "label": "ˋ ˈ ˉ ˊ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Chinantec-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Tone numbers": [
+          {
+            "name": "cv91",
+            "id": "tone-numbers-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Numbers",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Hide tone contour staves": [
+          {
+            "name": "cv92",
+            "id": "hide-tone-contour-staves-label",
+            "default": "0",
+            "label": "˥ ˦ ˧ ˨ ˩ ꜒ ꜓ ꜔ ꜕ ꜖ (˩˦˥˧˨ ꜖꜓꜒꜔꜕)",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Hide staves",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Numeral alternates": [
+      {
+        "Subscript numerals": [
+          {
+            "name": "subs",
+            "id": "subscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Subscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Superscript numerals": [
+          {
+            "name": "sups",
+            "id": "superscript-numerals-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Superscript",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Automatic fractions": [
+          {
+            "name": "frac",
+            "id": "automatic-fractions-label",
+            "default": "0",
+            "label": "1⁄2 456⁄789 1/2 456/789",
+            "Options": [
+              {
+                "tip": "Standard (none)",
+                "value": "0"
+              },
+              {
+                "tip": "Automatic",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Harmattan",
+    "id": "harmattan",
+    "Character variants": [
+      {
+       "Jeem/Hah": [
+          {
+            "name": "cv08",
+            "id": "jeem/hah-label",
+            "default": "0",
+            "label": "ج ججج ح ححح خ خخخ ڂ ڂڂڂ ڃ ڃڃڃ ڄ ڄڄڄ څ څڅڅ چ چچچ ڿ ڿڿڿ ݗ ݗݗݗ ݘ ݘݘݘ ࢊ ࢊࢊࢊ ࢢ ࢢࢢࢢ ࣁ ࣁࣁࣁ ࣅ ࣅࣅࣅ ࣆ ࣆࣆࣆ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Handwritten",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Dal": [
+          {
+            "name": "cv12",
+            "id": "dal-label",
+            "default": "0",
+            "label": "د ذ ڈ ډ ڊ ڋ ڌ ڍ ڎ ڏ ڐ ۮ ݙ ݚ ࢮ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Sad/Dad": [
+          {
+            "name": "cv20",
+            "id": "sad/dad-label",
+            "default": "0",
+            "label": "ص صصص ض ضضض ڝ ڝڝڝ ڞ ڞڞڞ ࢯࢯࢯ ࢯ ۻ ۻۻۻ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Half",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Meem": [
+          {
+            "name": "cv44",
+            "id": "meem-label",
+            "default": "0",
+            "label": "م ممم ݥ ݥݥݥ ݦ ݦݦݦ ࢧ ࢧࢧࢧ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Heh": [
+          {
+            "name": "cv48",
+            "id": "heh-label",
+            "default": "0",
+            "label": "ه ههه ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              },
+              {
+                "tip": "Urdu-style",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Heh Doachashmee": [
+          {
+            "name": "cv49",
+            "id": "heh-doachashmee-label",
+            "default": "0",
+            "label": "ھ ھھھ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Knotted",
+                "value": "1"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "Kyrgyz OE": [
+          {
+            "name": "cv51",
+            "id": "kyrgyz-oe-label",
+            "default": "0",
+            "label": "ۅ",
+            "Options": [
+              {
+                "tip": "Loop",
+                "value": "0"
+              },
+              {
+              "tip": "Bar",
+              "value": "1"
+            }
+          ]
+        }
+        ],
+        "Yeh Hamza": [
+          {
+            "name": "cv54",
+            "id": "yeh-hamza-label",
+            "default": "0",
+            "label": "ئ ‍ئ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hamza",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Maddah": [
+          {
+            "name": "cv60",
+            "id": "maddah-label",
+            "default": "0",
+            "label": "آ آ ◌ٓ ",
+            "Options": [
+              {
+                "tip": "Small",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Shadda+kasra placement": [
+          {
+            "name": "cv62",
+            "id": "shadda+kasra-placement-label",
+            "default": "0",
+            "label": "بِّ ◌ِّ بٍّ ◌ٍّ ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Lowered",
+                "value": "1"
+              },
+              {
+                "tip": "Raised",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Damma": [
+          {
+            "name": "cv70",
+            "id": "damma-label",
+            "default": "0",
+            "label": "بُ ◌ُ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Filled",
+                "value": "1"
+              },
+              {
+                "tip": "Short",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Dammatan": [
+          {
+            "name": "cv72",
+            "id": "dammatan-label",
+            "default": "0",
+            "label": "بٌ ◌ٌ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Six-nine",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Inverted Damma": [
+          {
+            "name": "cv74",
+            "id": "inverted-damma-label",
+            "default": "0",
+            "label": "بٗ ◌ٗ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Hollow",
+                "value": "1"
+              },
+              {
+                "tip": "Filled",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Superscript Alef": [
+          {
+            "name": "cv76",
+            "id": "superscript-alef-label",
+            "default": "0",
+            "label": "ؠٰ ؠٰؠٰ ئٰ ئٰئٰ سٰ سٰسٰ شٰ شٰشٰ صٰ صٰصٰ ضٰ ضٰضٰ ؽٰ ؽٰؽٰ ؾٰ ؾٰؾٰ ؿٰ ؿٰؿٰ ىٰ ىٰىٰ يٰ يٰيٰ ٸٰ ٸٰٸٰ ښٰ ښٰښٰ ڛٰ ڛٰڛٰ ڜٰ ڜٰڜٰ ڝٰ ڝٰڝٰ ڞٰ ڞٰڞٰ یٰ یٰیٰ ۍٰ بۍٰ ێٰ ێٰێٰ ېٰ ېٰېٰ ۑٰ ۑٰۑٰ ۺٰ ۺٰۺٰ ۻٰ ۻٰۻٰ ݜٰ ݜٰݜٰ ݭٰ ݭٰݭٰ ݰٰ ݰٰݰٰ ݽٰ ݽٰݽٰ ݾٰ ݾٰݾٰ ݵٰ ݵٰݵٰ ݶٰ ݶٰݶٰ ݷٰ ݷٰݷٰ ࢨٰ ࢨٰࢨٰ ࢩٰ ࢩٰࢩٰ ࢯٰ ࢯٰࢯٰ ࢺٰ ࢺٰࢺٰ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              },
+              {
+                "tip": "Small",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Sukun": [
+          {
+            "name": "cv78",
+            "id": "sukun-label",
+            "default": "0",
+            "label": "بْ ◌ْ",
+            "Options": [
+              {
+                "tip": "Closed",
+                "value": "0"
+              },
+              {
+                "tip": "Open down",
+                "value": "1"
+              },
+              {
+                "tip": "Open left",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "End of ayah": [
+          {
+            "name": "cv80",
+            "id": "end-of-ayah-label",
+            "default": "0",
+            "label": "‭۝123‬ ‭۝١٢٣‬",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Simplified A",
+                "value": "1"
+              },
+              {
+                "tip": "Simplified B",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Eastern digits": [
+          {
+            "name": "cv82",
+            "id": "eastern-digits-label",
+            "default": "0",
+            "label": "467",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              },
+              {
+                "tip": "Rohingya-style",
+                "value": "4"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              },
+              {
+                "tip": "Urdu-style",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Comma": [
+          {
+            "name": "cv84",
+            "id": "comma-label",
+            "default": "0",
+            "label": "، ؛",
+            "Options": [
+              {
+                "tip": "Upward",
+                "value": "0"
+              },
+              {
+                "tip": "Downward",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Decimal separator": [
+          {
+            "name": "cv85",
+            "id": "decimal-separator-label",
+            "default": "0",
+            "label": "٫",
+            "Options": [
+              {
+                "tip": "Small reh",
+                "value": "0"
+              },
+              {
+                "tip": "Slash",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Kanchenjunga",
+    "id": "kanchenjunga",
+    "Character variants": [
+      {
+        "Ca": [
+          {
+            "name": "cv05",
+            "id": "ca-label",
+            "default": "0",
+            "label": "𖵉",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ta": [
+          {
+            "name": "cv15",
+            "id": "ta-label",
+            "default": "0",
+            "label": "𖵒",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ma": [
+          {
+            "name": "cv25",
+            "id": "ma-label",
+            "default": "0",
+            "label": "𖵛",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Ha": [
+          {
+            "name": "cv35",
+            "id": "ha-label",
+            "default": "0",
+            "label": "𖵢",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Lateef",
+    "id": "lateef",
+    "Character variants": [
+      {
+        "Meem": [
+          {
+            "name": "cv44",
+            "id": "meem-label",
+            "default": "0",
+            "label": "م ممم ݥ ݥݥݥ ݦ ݦݦݦ ࢧ ࢧࢧࢧ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Heh": [
+          {
+            "name": "cv48",
+            "id": "heh-label",
+            "default": "0",
+            "label": "ه ههه ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              },
+              {
+                "tip": "Urdu-style",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Heh Doachashmee": [
+          {
+            "name": "cv49",
+            "id": "heh-doachashmee-label",
+            "default": "0",
+            "label": "ھ ھھھ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Knotted",
+                "value": "1"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "Kyrgyz OE": [
+          {
+            "name": "cv51",
+            "id": "kyrgyz-oe-label",
+            "default": "0",
+            "label": "ۅ",
+            "Options": [
+              {
+                "tip": "Loop",
+                "value": "0"
+              },
+              {
+                "tip": "Bar",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Yeh Hamza": [
+          {
+            "name": "cv54",
+            "id": "yeh-hamza-label",
+            "default": "0",
+            "label": "ئ ‍ئ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hamza",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Shadda+kasra placement": [
+          {
+            "name": "cv62",
+            "id": "shadda+kasra-placement-label",
+            "default": "0",
+            "label": "بِّ ◌ِّ بٍّ ◌ٍّ ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Lowered",
+                "value": "1"
+              },
+              {
+                "tip": "Raised",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Damma": [
+          {
+            "name": "cv70",
+            "id": "damma-label",
+            "default": "0",
+            "label": "بُ ◌ُ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Filled",
+                "value": "1"
+              },
+              {
+                "tip": "Short",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Dammatan": [
+          {
+            "name": "cv72",
+            "id": "dammatan-label",
+            "default": "0",
+            "label": "بٌ ◌ٌ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Six-nine",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Inverted Damma": [
+          {
+            "name": "cv74",
+            "id": "inverted-damma-label",
+            "default": "0",
+            "label": "بٗ ◌ٗ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Hollow",
+                "value": "1"
+              },
+              {
+                "tip": "Filled",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Superscript Alef": [
+          {
+            "name": "cv76",
+            "id": "superscript-alef-label",
+            "default": "0",
+            "label": "ؠٰ ؠٰؠٰ ئٰ ئٰئٰ سٰ سٰسٰ شٰ شٰشٰ صٰ صٰصٰ ضٰ ضٰضٰ ؽٰ ؽٰؽٰ ؾٰ ؾٰؾٰ ؿٰ ؿٰؿٰ ىٰ ىٰىٰ يٰ يٰيٰ ٸٰ ٸٰٸٰ ښٰ ښٰښٰ ڛٰ ڛٰڛٰ ڜٰ ڜٰڜٰ ڝٰ ڝٰڝٰ ڞٰ ڞٰڞٰ یٰ یٰیٰ ۍٰ بۍٰ ێٰ ێٰێٰ ېٰ ېٰېٰ ۑٰ ۑٰۑٰ ۺٰ ۺٰۺٰ ۻٰ ۻٰۻٰ ݜٰ ݜٰݜٰ ݭٰ ݭٰݭٰ ݰٰ ݰٰݰٰ ݽٰ ݽٰݽٰ ݾٰ ݾٰݾٰ ݵٰ ݵٰݵٰ ݶٰ ݶٰݶٰ ݷٰ ݷٰݷٰ ࢨٰ ࢨٰࢨٰ ࢩٰ ࢩٰࢩٰ ࢯٰ ࢯٰࢯٰ ࢺٰ ࢺٰࢺٰ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              },
+              {
+                "tip": "Small",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Sukun": [
+          {
+            "name": "cv78",
+            "id": "sukun-label",
+            "default": "0",
+            "label": "بْ ◌ْ",
+            "Options": [
+              {
+                "tip": "Closed",
+                "value": "0"
+              },
+              {
+                "tip": "Open down",
+                "value": "1"
+              },
+              {
+                "tip": "Open left",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "End of ayah": [
+          {
+            "name": "cv80",
+            "id": "end-of-ayah-label",
+            "default": "",
+            "label": "",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Simplified A",
+                "value": "1"
+              },
+              {
+                "tip": "Simplified B",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Eastern digits": [
+          {
+            "name": "cv82",
+            "id": "eastern-digits-label",
+            "default": "0",
+            "label": "467",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              },
+              {
+                "tip": "Rohingya-style",
+                "value": "4"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              },
+              {
+                "tip": "Urdu-style",
+                "value": "2"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Proportional figures": [
+      {
+        "Proportional figures": [
+          {
+            "name": "pnum",
+            "id": "proportional-figures-label",
+            "default": "0",
+            "label": "123456789",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Tabular figures": [
+      {
+        "Tabular figures": [
+          {
+            "name": "tnum",
+            "id": "tabular-figures-label",
+            "default": "0",
+            "label": "٠١٢٣٤٥٦٧٨٩ ۰۱۲۳۵۶۷۸۹",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Comma": [
+          {
+            "name": "cv84",
+            "id": "comma-label",
+            "default": "0",
+            "label": "، ؛",
+            "Options": [
+              {
+                "tip": "Upward",
+                "value": "0"
+              },
+              {
+                "tip": "Downward",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Decimal separator": [
+          {
+            "name": "cv85",
+            "id": "decimal-separator-label",
+            "default": "0",
+            "label": "٫",
+            "Options": [
+              {
+                "tip": "Small reh",
+                "value": "0"
+              },
+              {
+                "tip": "Slash",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Padauk",
+    "id": "padauk",
+    "User-selected features": [
+      {
+        "Filled dots": [
+          {
+            "name": "cv01",
+            "id": "filled-dots-label",
+            "default": "0",
+            "label": "ံ း ႇ ႈ ႉ ႊ ႚ ႛ ꩻ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Tear drop style washwe": [
+          {
+            "name": "cv02",
+            "id": "tear-drop-style-washwe-label",
+            "default": "0",
+            "label": "တွ ျွ ြွ ွှ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Asho Chin variants(U+106D)": [
+          {
+            "name": "cv03",
+            "id": "asho-chin-variants(u+106d)-label",
+            "default": "0",
+            "label": "ကၭ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Thai Mon variants": [
+          {
+            "name": "cv04",
+            "id": "thai-mon-variants-label",
+            "default": "0",
+            "label": "ဃ ဋ ဌ ဍ ဎ ဒ န သ ဠ အ ဣ ဿ ၉ ၊ ။ ၚ်္",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Aiton Phake special": [
+          {
+            "name": "cv05",
+            "id": "aiton-phake-special-label",
+            "default": "0",
+            "label": "က︀ ၵ︀ ꩡ︀ ၺ တ︀ ꩫ︀ ၸ︀ ယ︀ ꩺ လ︀ ꩭ ဢ︀ ြ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Khamti variants(U+1086)": [
+          {
+            "name": "cv06",
+            "id": "khamti-variants(u+1086)-label",
+            "default": "0",
+            "label": " ႆ ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Slanted hato": [
+          {
+            "name": "cv07",
+            "id": "slanted-hato-label",
+            "default": "0",
+            "label": "ှ ှု ှူ ၡ ၦ",
+            "Options": [
+              {
+                "tip": "Upright",
+                "value": "0"
+              },
+              {
+                "tip": "Sgaw style slanted leg with horizontal foot",
+                "value": "1"
+              },
+              {
+                "tip": "Slanted leg with right angled foot",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Tai Laing variant": [
+          {
+            "name": "cv09",
+            "id": "tai-laing-variant-label",
+            "default": "0",
+            "label": " ꩬ ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Lower dot shifts left": [
+          {
+            "name": "lldt",
+            "id": "lower-dot-shifts-left-label",
+            "default": "0",
+            "label": "ရ့ ရံ့ ကှ့",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Long U with Yayit, long UU with Hato": [
+          {
+            "name": "ulon",
+            "id": "long-u-with-yayit,-long-uu-with-hato-label",
+            "default": "0",
+            "label": "ကြု ကှူ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "U and UU always full height": [
+          {
+            "name": "utal",
+            "id": "u-and-uu-always-full-height-label",
+            "default": "0",
+            "label": "ု ူ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Insert dotted circles for errors (any combining mark)": [
+          {
+            "name": "dotc",
+            "id": "insert-dotted-circles-for-errors-(any-combining-mark)-label",
+            "default": "1",
+            "label": "ှူ",
+            "Options": [
+              {
+                "tip": "Yes",
+                "value": "1"
+              },
+              {
+                "tip": "No",
+                "value": "0"
+              }
+            ]
+          }
+        ],
+        "Disable great nnya": [
+          {
+            "name": "nnya",
+            "id": "disable-great-nnya-label",
+            "default": "0",
+            "label": "ည္ည",
+            "Options": [
+              {
+                "tip": "Yes",
+                "value": "0"
+              },
+              {
+                "tip": "No",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Variant tta": [
+          {
+            "name": "(U+100B)",
+            "id": "variant-tta-label",
+            "default": "0",
+            "label": "ဋ ဋဌ ဏဋ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Move ldot right when possible": [
+          {
+            "name": "dotr",
+            "id": "move-ldot-right-when-possible-label",
+            "default": "0",
+            "label": "ကြ့",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ]          
+      }
+    ]
+  },
+  {
+    "name": "Ruwudu",
+    "id": "ruwudu",
+    "Stylistic Sets": [
+      {
+        "Imala e": [
+          {
+            "name": "ss04",
+            "id": "imala-e-label",
+            "default": "0",
+            "label": "بٜ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Jeem/Hah": [
+          {
+            "name": "ss07",
+            "id": "jeem/hah-label",
+            "default": "0",
+            "label": "ج ججج ح ححح خ خخخ ڃ ڃڃڃ ڄ ڄڄڄ ࢢ ࢢࢢࢢ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Flat style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Alef diacritic placement": [
+          {
+            "name": "ss08",
+            "id": "alef-diacritic-placement-label",
+            "default": "0",
+            "label": "اَ اُ اِ باَ باُ باِ ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Touching",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Wagaf": [
+          {
+            "name": "ss09",
+            "id": "wagaf-label",
+            "default": "0",
+            "label": "ؿ ؿؿؿ ڟ ڟڟڟ ݑ ݑݑݑ ݣ ݣݣݣ ࣃ ࣃࣃࣃ ࣄ ࣄࣄࣄ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Small",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "End of ayah": [
+          {
+            "name": "ss02",
+            "id": "end-of-ayah-label",
+            "default": "",
+            "label": "‭۝123‬ ‭۝١٢٣‬",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "End of ayah A",
+                "value": "1"
+              },
+              {
+                "tip": "End of ayah B",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Proportional Figures": [
+      {
+        "Proportional Figures": [
+          {
+            "name": "pnum",
+            "id": "proportional-figures-label",
+            "default": "0",
+            "label": "0 1 2 3 4 5 6 7 8 9",
+            "Options": [
+              {
+                "tip": "Tabular Figures",
+                "value": "0"
+              },
+              {
+                "tip": "Proportional Figures",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Scheherazade New",
+    "id": "scheherazade-new",
+    "Character variants": [
+      {
+       "Dal": [
+          {
+            "name": "cv12",
+            "id": "dal-label",
+            "default": "0",
+            "label": "د ذ ڈ ډ ڊ ڋ ڌ ڍ ڎ ڏ ڐ ۮ ݙ ݚ ࢮ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Alternate",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Meem": [
+          {
+            "name": "cv44",
+            "id": "meem-label",
+            "default": "0",
+            "label": "م ممم ݥ ݥݥݥ ݦ ݦݦݦ ࢧ ࢧࢧࢧ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Heh": [
+          {
+            "name": "cv48",
+            "id": "heh-label",
+            "default": "0",
+            "label": "ه ههه",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              },
+              {
+                "tip": "Urdu-style",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Heh Doachashmee": [
+          {
+            "name": "cv49",
+            "id": "heh-doachashmee-label",
+            "default": "0",
+            "label": "ھ ھھھ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Knotted",
+                "value": "1"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              }
+            ]
+          }
+        ],
+        "Kyrgyz OE": [
+          {
+            "name": "cv51",
+            "id": "kyrgyz-oe-label",
+            "default": "0",
+            "label": "ۅ",
+            "Options": [
+              {
+                "tip": "Loop",
+                "value": "0"
+              },
+              {
+                "tip": "Bar",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Yeh Hamza": [
+          {
+            "name": "cv54",
+            "id": "yeh-hamza-label",
+            "default": "0",
+            "label": "ئ ‍ئ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Right hamza",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Maddah": [
+          {
+            "name": "cv60",
+            "id": "maddah-label",
+            "default": "0",
+            "label": "آ آ ◌ٓ",
+            "Options": [
+              {
+                "tip": "Small",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Shadda+kasra placement": [
+          {
+            "name": "cv62",
+            "id": "shadda+kasra-placement-label",
+            "default": "0",
+            "label": "بِّ ◌ِّ بٍّ ◌ٍّ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Lowered",
+                "value": "1"
+              },
+              {
+                "tip": "Raised",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Damma": [
+          {
+            "name": "cv70",
+            "id": "damma-label",
+            "default": "0",
+            "label": "بُ ◌ُ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Filled",
+                "value": "1"
+              },
+              {
+                "tip": "Short",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Dammatan": [
+          {
+            "name": "cv72",
+            "id": "dammatan-label",
+            "default": "0",
+            "label": "بٌ ◌ٌ",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Six-nine",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "Inverted Damma": [
+          {
+            "name": "cv74",
+            "id": "inverted-damma-label",
+            "default": "0",
+            "label": "بٗ ◌ٗ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Hollow",
+                "value": "1"
+              },
+              {
+                "tip": "Filled",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Superscript Alef": [
+          {
+            "name": "cv76",
+            "id": "superscript-alef-label",
+            "default": "0",
+            "label": "ؠٰ ؠٰؠٰ ئٰ ئٰئٰ سٰ سٰسٰ شٰ شٰشٰ صٰ صٰصٰ ضٰ ضٰضٰ ؽٰ ؽٰؽٰ ؾٰ ؾٰؾٰ ؿٰ ؿٰؿٰ ىٰ ىٰىٰ يٰ يٰيٰ ٸٰ ٸٰٸٰ ښٰ ښٰښٰ ڛٰ ڛٰڛٰ ڜٰ ڜٰڜٰ ڝٰ ڝٰڝٰ ڞٰ ڞٰڞٰ یٰ یٰیٰ ۍٰ بۍٰ ێٰ ێٰێٰ ېٰ ېٰېٰ ۑٰ ۑٰۑٰ ۺٰ ۺٰۺٰ ۻٰ ۻٰۻٰ ݜٰ ݜٰݜٰ ݭٰ ݭٰݭٰ ݰٰ ݰٰݰٰ ݽٰ ݽٰݽٰ ݾٰ ݾٰݾٰ ݵٰ ݵٰݵٰ ݶٰ ݶٰݶٰ ݷٰ ݷٰݷٰ ࢨٰ ࢨٰࢨٰ ࢩٰ ࢩٰࢩٰ ࢯٰ ࢯٰࢯٰ ࢺٰ ࢺٰࢺٰ",
+            "Options": [
+              {
+                "tip": "Default",
+                "value": "0"
+              },
+              {
+                "tip": "Large",
+                "value": "1"
+              },
+              {
+                "tip": "Small",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Sukun": [
+          {
+            "name": "cv78",
+            "id": "sukun-label",
+            "default": "0",
+            "label": "بْ ◌ْ",
+            "Options": [
+              {
+                "tip": "Closed",
+                "value": "0"
+              },
+              {
+                "tip": "Open down",
+                "value": "1"
+              },
+              {
+                "tip": "Open left",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "End of ayah": [
+          {
+            "name": "cv80",
+            "id": "end-of-ayah-label",
+            "default": "0",
+            "label": "‭۝123‬ ‭۝١٢٣‬",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Simplified A",
+                "value": "1"
+              },
+              {
+                "tip": "Simplified B",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Honorific ligatures": [
+          {
+            "name": "cv81",
+            "id": "honorific-ligatures-label",
+            "default": "0",
+            "label": "﵀﵁﵂﵃﵄﵅﵆﵇﵈﵉﵊﵋﵌﵍﵎﵏ ﷏ﷺﷻ﷽﷿﷿",
+            "Options": [
+              {
+                "tip": "Calligraphic",
+                "value": "0"
+              },
+              {
+                "tip": "Simplified",
+                "value": "1"
+              },
+              {
+                "tip": "",
+                "value": ""
+              }
+            ]
+          }
+        ],
+        "Eastern digits": [
+          {
+            "name": "cv82",
+            "id": "eastern-digits-label",
+            "default": "0",
+            "label": "467",
+            "Options": [
+              {
+                "tip": "Standard",
+                "value": "0"
+              },
+              {
+                "tip": "Kurdish-style",
+                "value": "3"
+              },
+              {
+                "tip": "Rohingya-style",
+                "value": "4"
+              },
+              {
+                "tip": "Sindhi-style",
+                "value": "1"
+              },
+              {
+                "tip": "Urdu-style",
+                "value": "2"
+              }
+            ]
+          }
+        ],
+        "Comma": [
+          {
+            "name": "cv84",
+            "id": "comma-label",
+            "default": "0",
+            "label": "، ؛",
+            "Options": [
+              {
+                "tip": "Upward",
+                "value": "0"
+              },
+              {
+                "tip": "Downward",
+                "value": "1"
+              },
+              {
+                "tip": "Decimal separator",
+                "value": ""
+              }
+            ]
+          }
+        ],
+        "Decimal separator": [
+          {
+            "name": "cv85",
+            "id": "decimal-separator-label",
+            "default": "0",
+            "label": "٫",
+            "Options": [
+              {
+                "tip": "Small reh",
+                "value": "0"
+              },
+              {
+                "tip": "Slash",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+   ]
+  },
+  {
+    "name": "Tagmukay",
+    "id": "tagmukay",
+    "User-selected features": [
+      {
+        "enja stylistic variant": [
+          {
+            "name": "ss01",
+            "id": "enja-stylistic-variant-label",
+            "default": "0",
+            "label": "ⵏ",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ],
+        "a and g variants": [
+            {
+            "name": "ss02",
+            "id": "a-and-g-variants-label",
+            "default": "0",
+            "label": "a à á â ã ä å g",
+            "Options": [
+              {
+                "tip": "No",
+                "value": "0"
+              },
+              {
+                "tip": "Yes",
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Add -moz and -webkit to radio label font-feature settings options (_However, font-features are still not yet working in Android in the ClickAway settings Box_)
- Remove iPad manual override for Graphite Fonts as Graphite is not included in FF on iPad
- Add json files for Graphite-enabled font-feature settings
- Correct punctuation label (Awami Nastaliq font-feature)